### PR TITLE
feat(backend): Validate environment variables on startup with Zod                                                                                                   

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,8 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
-        "jsonwebtoken": "^9.0.2"
+        "jsonwebtoken": "^9.0.2",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "jest": "^29.7.0",
@@ -51,7 +52,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -1563,7 +1563,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5641,6 +5640,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,14 +9,15 @@
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0",
+    "cors": "^2.8.5",
+    "dotenv": "^16.3.1",
     "express": "^4.18.2",
     "jsonwebtoken": "^9.0.2",
-    "dotenv": "^16.3.1",
-    "cors": "^2.8.5"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "jest": "^29.7.0",
-    "supertest": "^6.3.4",
-    "nodemon": "^3.0.2"
+    "nodemon": "^3.0.2",
+    "supertest": "^6.3.4"
   }
 }

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+require('./config');
 const express = require('express');
 const cors = require('cors');
 

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -1,0 +1,28 @@
+const { z } = require('zod');
+
+const schema = z.object({
+  // Stellar / Soroban
+  STELLAR_NETWORK: z.enum(['testnet', 'mainnet']).default('testnet'),
+  HORIZON_URL: z.string().url(),
+  SOROBAN_RPC_URL: z.string().url(),
+  STELLAR_NETWORK_PASSPHRASE: z.string().min(1),
+
+  // Contract
+  VACCINATIONS_CONTRACT_ID: z.string().min(1),
+
+  // Backend
+  ADMIN_SECRET_KEY: z.string().min(1),
+  SEP10_SERVER_KEY: z.string().min(1),
+  JWT_SECRET: z.string().min(1),
+  PORT: z.coerce.number().int().positive().default(4000),
+});
+
+const result = schema.safeParse(process.env);
+
+if (!result.success) {
+  const missing = result.error.issues.map(i => `  ${i.path[0]}: ${i.message}`).join('\n');
+  console.error(`[config] Missing or invalid environment variables:\n${missing}`);
+  process.exit(1);
+}
+
+module.exports = result.data;


### PR DESCRIPTION
Summary                                                                                        
                                                                                                 
  Adds startup environment variable validation to prevent the server from running with missing or
  misconfigured config.                                                                          
                                                                                                 
  Changes                                                                                        
                                                                                                 
  - Added backend/src/config.js — Zod schema that validates all required env vars on startup     
  - Updated backend/src/app.js — imports config before server initialization                     
  - Installed zod as a production dependency                                                     
                                                                                                 
  Behavior                                                                                       
                                                                                                 
  - Server exits immediately on startup with a clear, itemized error if any required var is      
  missing or invalid                                                                             
  - Optional vars (STELLAR_NETWORK, PORT) fall back to documented defaults                       
  - No runtime surprises from undefined env vars reaching contract or auth logic                 
                                                                                                 
  Required Vars                                                                                  
                                                                                                 
  HORIZON_URL, SOROBAN_RPC_URL, STELLAR_NETWORK_PASSPHRASE, VACCINATIONS_CONTRACT_ID,            
  ADMIN_SECRET_KEY, SEP10_SERVER_KEY, JWT_SECRET                                                 
                                                                                                 
  Defaults                                                                                       
                                                                                                 
  ┌───────────────────┬───────────┐                                                              
  │ Var               │ Default   │                                                              
  ├───────────────────┼───────────┤                                                              
  │ `STELLAR_NETWORK` │ `testnet` │                                                              
  │ `PORT`            │ `4000`    │                                                              
  └───────────────────┴───────────┘                                                              
                                                                                                 
  Testing                                                                                        
                                                                                                 
  Copy .env.example to .env, omit a required var, and run npm start — the process exits with a   
  clear message listing the offending variable(s).                                               
                                                                                                 
closes #39                                    