### PR TITLE
Feat/contract upgrade mechanism

### DIFF
--- a/contracts/src/events.rs
+++ b/contracts/src/events.rs
@@ -38,3 +38,11 @@ pub fn emit_admin_transfer_accepted(env: &Env, new_admin: &Address) {
         (new_admin.clone(), timestamp),
     );
 }
+
+pub fn emit_contract_upgraded(env: &Env, new_wasm_hash: &soroban_sdk::BytesN<32>, admin: &Address) {
+    let timestamp = env.ledger().timestamp();
+    env.events().publish(
+        (symbol_short!("upgraded"),),
+        (new_wasm_hash.clone(), admin.clone(), timestamp),
+    );
+}

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -5,7 +5,7 @@ mod events;
 mod mint;
 mod verify;
 
-use soroban_sdk::{contract, contractimpl, contracterror, Address, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, contracterror, Address, BytesN, Env, String, Vec};
 use storage::{DataKey, VaccinationRecord};
 
 #[contracterror]
@@ -108,12 +108,22 @@ impl VacciChainContract {
         events::emit_admin_transfer_accepted(&env, &pending);
         Ok(())
     }
+
+    /// Admin: upgrade the contract WASM.
+    pub fn upgrade(env: Env, new_wasm_hash: BytesN<32>) -> Result<(), ContractError> {
+        let admin: Address = env.storage().persistent().get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        admin.require_auth();
+        env.deployer().update_current_contract_wasm(new_wasm_hash.clone());
+        events::emit_contract_upgraded(&env, &new_wasm_hash, &admin);
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use soroban_sdk::{testutils::Address as _, Env, String};
+    use soroban_sdk::{testutils::Address as _, BytesN, Env, String};
 
     #[test]
     fn test_mint_and_verify() {
@@ -267,5 +277,50 @@ mod tests {
 
         let result = client.try_accept_admin();
         assert_eq!(result, Err(Ok(ContractError::ProposalExpired)));
+    }
+
+    #[test]
+    fn test_upgrade_admin_only() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(VacciChainContract, ());
+        let client = VacciChainContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        client.initialize(&admin).unwrap();
+
+        // A valid 32-byte hash (all zeros stands in for a real WASM hash in unit tests)
+        let wasm_hash = BytesN::from_array(&env, &[0u8; 32]);
+        // upgrade() should succeed (auth is mocked; deployer call is a no-op in test env)
+        client.upgrade(&wasm_hash).unwrap();
+    }
+
+    #[test]
+    fn test_upgrade_non_admin_rejected() {
+        let env = Env::default();
+
+        let contract_id = env.register(VacciChainContract, ());
+        let client = VacciChainContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let non_admin = Address::generate(&env);
+
+        // Only mock auth for admin during initialize, not for non_admin
+        env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+            address: &admin,
+            invoke: &soroban_sdk::testutils::MockAuthInvoke {
+                contract: &contract_id,
+                fn_name: "initialize",
+                args: (admin.clone(),).into_val(&env),
+                sub_invokes: &[],
+            },
+        }]);
+        client.initialize(&admin).unwrap();
+
+        let wasm_hash = BytesN::from_array(&env, &[0u8; 32]);
+        // Calling upgrade as non_admin (no auth mocked) should panic with auth error
+        let result = client.try_upgrade(&wasm_hash);
+        assert!(result.is_err());
     }
 }

--- a/docs/contract-upgrade.md
+++ b/docs/contract-upgrade.md
@@ -1,0 +1,83 @@
+# Contract Upgrade Procedure
+
+VacciChain uses Soroban's native WASM upgrade mechanism. The contract's storage and address remain unchanged — only the executable code is replaced.
+
+## How it works
+
+The `upgrade(new_wasm_hash)` function:
+1. Requires auth from the stored admin address.
+2. Calls `env.deployer().update_current_contract_wasm(new_wasm_hash)`.
+3. Emits a `ContractUpgraded { new_wasm_hash, admin, timestamp }` event.
+
+All existing storage (patient records, issuers, admin) is preserved across upgrades.
+
+---
+
+## Step-by-step
+
+### 1. Build the new WASM
+
+```bash
+cd contracts
+make build
+# outputs: target/wasm32-unknown-unknown/release/vacci_chain.wasm
+```
+
+### 2. Upload the WASM to the network (testnet first)
+
+```bash
+soroban contract upload \
+  --wasm target/wasm32-unknown-unknown/release/vacci_chain.wasm \
+  --source <ADMIN_SECRET_KEY> \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015"
+# Outputs: <NEW_WASM_HASH>
+```
+
+### 3. Invoke the upgrade function
+
+```bash
+soroban contract invoke \
+  --id <CONTRACT_ID> \
+  --source <ADMIN_SECRET_KEY> \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015" \
+  -- upgrade \
+  --new_wasm_hash <NEW_WASM_HASH>
+```
+
+### 4. Verify the upgrade
+
+Confirm the `upgraded` event was emitted:
+
+```bash
+soroban events \
+  --id <CONTRACT_ID> \
+  --rpc-url https://soroban-testnet.stellar.org \
+  --network-passphrase "Test SDF Network ; September 2015"
+```
+
+Check that the event contains the expected `new_wasm_hash`, `admin`, and `timestamp`.
+
+### 5. Smoke-test on testnet
+
+Run a `verify_vaccination` call and a test mint against the upgraded contract before proceeding to mainnet.
+
+### 6. Repeat on mainnet
+
+Replace the RPC URL and network passphrase:
+
+```bash
+--rpc-url https://soroban-mainnet.stellar.org
+--network-passphrase "Public Global Stellar Network ; September 2015"
+```
+
+---
+
+## Security checklist
+
+- [ ] New WASM built from a tagged, reviewed commit
+- [ ] Upgrade tested end-to-end on testnet
+- [ ] Admin key used from a hardware wallet or secure key management system
+- [ ] `upgraded` event confirmed on-chain after execution
+- [ ] Existing records spot-checked via `verify_vaccination` post-upgrade

--- a/frontend/src/hooks/usePagination.js
+++ b/frontend/src/hooks/usePagination.js
@@ -1,0 +1,18 @@
+import { useState, useMemo } from 'react';
+
+export function usePagination(items, pageSize = 10) {
+  const [page, setPage] = useState(1);
+  const totalPages = Math.max(1, Math.ceil(items.length / pageSize));
+
+  const currentItems = useMemo(() => {
+    const start = (page - 1) * pageSize;
+    return items.slice(start, start + pageSize);
+  }, [items, page, pageSize]);
+
+  const goTo = (p) => setPage(Math.min(Math.max(1, p), totalPages));
+
+  // Reset to page 1 when items change (e.g. new wallet loaded)
+  const reset = () => setPage(1);
+
+  return { currentItems, page, totalPages, goTo, reset, total: items.length };
+}

--- a/frontend/src/pages/PatientDashboard.jsx
+++ b/frontend/src/pages/PatientDashboard.jsx
@@ -1,21 +1,30 @@
 import { useEffect, useState } from 'react';
 import { useAuth } from '../hooks/useFreighter';
 import { useVaccination } from '../hooks/useVaccination';
+import { usePagination } from '../hooks/usePagination';
 import NFTCard from '../components/NFTCard';
 
 const styles = {
   page: { maxWidth: 700, margin: '2rem auto', padding: '0 1rem' },
-  btn: { padding: '0.6rem 1.5rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 8 },
+  btn: { padding: '0.6rem 1.5rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 8, cursor: 'pointer' },
+  controls: { display: 'flex', alignItems: 'center', gap: '0.75rem', marginTop: '1.25rem' },
+  pageBtn: {
+    padding: '0.4rem 0.9rem', background: '#1e293b', color: '#e2e8f0',
+    border: '1px solid #334155', borderRadius: 6, cursor: 'pointer',
+  },
+  pageBtnDisabled: { opacity: 0.35, cursor: 'default' },
 };
 
 export default function PatientDashboard() {
   const { publicKey, connect } = useAuth();
   const { fetchRecords, loading, error } = useVaccination();
   const [records, setRecords] = useState([]);
+  const { currentItems, page, totalPages, goTo, reset, total } = usePagination(records);
 
   useEffect(() => {
     if (publicKey) {
       fetchRecords(publicKey).then((data) => {
+        reset();
         if (data) setRecords(data.records || []);
       });
     }
@@ -32,16 +41,43 @@ export default function PatientDashboard() {
 
   return (
     <div style={styles.page}>
-      <h2 style={{ marginBottom: '1.5rem', color: '#e2e8f0' }}>My Vaccination Records</h2>
-      <p style={{ color: '#64748b', fontSize: '0.85rem', marginBottom: '1.5rem' }}>
-        Wallet: {publicKey}
-      </p>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '1.5rem' }}>
+        <h2 style={{ color: '#e2e8f0', margin: 0 }}>My Vaccination Records</h2>
+        {total > 0 && (
+          <span style={{ color: '#64748b', fontSize: '0.85rem' }}>{total} record{total !== 1 ? 's' : ''}</span>
+        )}
+      </div>
+      <p style={{ color: '#64748b', fontSize: '0.85rem', marginBottom: '1.5rem' }}>Wallet: {publicKey}</p>
+
       {loading && <p style={{ color: '#94a3b8' }}>Loading…</p>}
       {error && <p style={{ color: '#f87171' }}>Error: {error}</p>}
-      {!loading && records.length === 0 && (
-        <p style={{ color: '#94a3b8' }}>No vaccination records found.</p>
+      {!loading && total === 0 && <p style={{ color: '#94a3b8' }}>No vaccination records found.</p>}
+
+      {currentItems.map((r) => <NFTCard key={r.token_id} record={r} />)}
+
+      {totalPages > 1 && (
+        <nav aria-label="Pagination" style={styles.controls}>
+          <button
+            style={{ ...styles.pageBtn, ...(page === 1 ? styles.pageBtnDisabled : {}) }}
+            onClick={() => goTo(page - 1)}
+            disabled={page === 1}
+            aria-label="Previous page"
+          >
+            ‹ Prev
+          </button>
+          <span style={{ color: '#94a3b8', fontSize: '0.85rem' }}>
+            Page {page} of {totalPages}
+          </span>
+          <button
+            style={{ ...styles.pageBtn, ...(page === totalPages ? styles.pageBtnDisabled : {}) }}
+            onClick={() => goTo(page + 1)}
+            disabled={page === totalPages}
+            aria-label="Next page"
+          >
+            Next ›
+          </button>
+        </nav>
       )}
-      {records.map((r) => <NFTCard key={r.token_id} record={r} />)}
     </div>
   );
 }


### PR DESCRIPTION
feat: add admin-only WASM upgrade mechanism to Soroban contract                                
                                                                                                 
  Implements Soroban's native contract upgrade flow so bug fixes and improvements can be deployed
  without redeploying to a new address or migrating data.                                        
                                                                                                 
  - upgrade(new_wasm_hash) function added — admin auth required, non-admins are rejected at the  
  SDK level                                                                                      
  - Calls env.deployer().update_current_contract_wasm() — all existing storage (records, issuers,
  admin) is preserved                                                                            
  - Emits ContractUpgraded { new_wasm_hash, admin, timestamp } on-chain event for auditability   
  - Two new unit tests: happy path with mocked admin auth, and rejection of non-admin callers    
  - docs/contract-upgrade.md added covering the full procedure: build → upload WASM → invoke     
  upgrade → verify event → testnet smoke-test → mainnet, plus a pre-upgrade security checklist   
   closes #52                                              