### PR TITLE
feat: show dismissible banner when Freighter is not installed

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import PatientDashboard from './pages/PatientDashboard';
 import IssuerDashboard from './pages/IssuerDashboard';
 import VerifyPage from './pages/VerifyPage';
 import { AuthProvider } from './hooks/useFreighter';
+import FreighterBanner from './components/FreighterBanner';
 
 export default function App() {
   return (
@@ -15,6 +16,7 @@ export default function App() {
         <Link to="/issuer">Issue</Link>
         <Link to="/verify">Verify</Link>
       </nav>
+      <FreighterBanner />
       <Routes>
         <Route path="/" element={<Landing />} />
         <Route path="/patient" element={<PatientDashboard />} />

--- a/frontend/src/components/FreighterBanner.jsx
+++ b/frontend/src/components/FreighterBanner.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react';
+import { useAuth } from '../hooks/useFreighter';
+
+const INSTALL_URL = 'https://www.freighter.app/';
+
+export default function FreighterBanner() {
+  const { freighterInstalled } = useAuth();
+  const [dismissed, setDismissed] = useState(false);
+
+  if (freighterInstalled || dismissed) return null;
+
+  return (
+    <div style={{
+      background: '#7c3aed', color: '#fff', padding: '0.6rem 1.5rem',
+      display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: '1rem',
+    }}>
+      <span>
+        🦊 Freighter wallet not detected.{' '}
+        <a href={INSTALL_URL} target="_blank" rel="noreferrer" style={{ color: '#e9d5ff', fontWeight: 600 }}>
+          Install Freighter
+        </a>{' '}
+        to connect your wallet and issue or view records.
+      </span>
+      <button
+        onClick={() => setDismissed(true)}
+        aria-label="Dismiss"
+        style={{ background: 'none', border: 'none', color: '#fff', fontSize: '1.2rem', cursor: 'pointer', lineHeight: 1 }}
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useFreighter.js
+++ b/frontend/src/hooks/useFreighter.js
@@ -12,7 +12,7 @@ export function AuthProvider({ children }) {
   const [publicKey, setPublicKey] = useState(null);
   const [token, setToken] = useState(null);
   const [role, setRole] = useState(null);
-  const [freighterInstalled, setFreighterInstalled] = useState(true);
+  const [freighterInstalled, setFreighterInstalled] = useState(() => typeof window !== 'undefined' && !!window.freighter);
 
   const connect = useCallback(async () => {
     const connected = await isConnected();


### PR DESCRIPTION
Detect missing Freighter wallet and show install prompt
  
  When Freighter is not installed, wallet interactions would fail silently with a JS error. This change surfaces a
  clear prompt to the user instead.
  
  Changes:
  
  - useFreighter.js — initialize freighterInstalled by checking window.freighter on mount (synchronous, no connect
  required)
  - FreighterBanner.jsx — new dismissible banner with a link to the Freighter install page
  - App.jsx — render banner at the app shell level so it appears on all pages
  
  Behavior:
  
  - Banner appears immediately on load if Freighter is absent
  - Dismissible via × button; does not block any page
  - VerifyPage remains fully functional without a wallet — the banner is non-blocking

closes #11 