### PR TITLE
feat: add skeleton loader, error retry, and empty state to PatientDashboard

### DIFF
--- a/frontend/src/components/NFTCardSkeleton.jsx
+++ b/frontend/src/components/NFTCardSkeleton.jsx
@@ -1,0 +1,33 @@
+const bar = (w, h = 14, mb = 0) => ({
+  background: '#1e293b',
+  borderRadius: 6,
+  width: w,
+  height: h,
+  marginBottom: mb,
+  animation: 'vacciPulse 1.4s ease-in-out infinite',
+});
+
+const card = {
+  border: '1px solid #334155',
+  borderRadius: 12,
+  padding: '1.25rem',
+  marginBottom: '1rem',
+};
+
+export default function NFTCardSkeleton({ count = 3 }) {
+  return (
+    <>
+      <style>{`@keyframes vacciPulse{0%,100%{opacity:.4}50%{opacity:1}}`}</style>
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} style={card}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 10 }}>
+            <div style={bar('55%', 16)} />
+            <div style={bar(40)} />
+          </div>
+          <div style={bar('40%', 13, 6)} />
+          <div style={bar('60%', 12)} />
+        </div>
+      ))}
+    </>
+  );
+}

--- a/frontend/src/pages/PatientDashboard.jsx
+++ b/frontend/src/pages/PatientDashboard.jsx
@@ -1,8 +1,9 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useAuth } from '../hooks/useFreighter';
 import { useVaccination } from '../hooks/useVaccination';
 import { usePagination } from '../hooks/usePagination';
 import NFTCard from '../components/NFTCard';
+import NFTCardSkeleton from '../components/NFTCardSkeleton';
 import RecordDetailModal from '../components/RecordDetailModal';
 
 const styles = {
@@ -22,14 +23,15 @@ export default function PatientDashboard() {
   const [records, setRecords] = useState([]);
   const { currentItems, page, totalPages, goTo, reset, total } = usePagination(records);
 
-  useEffect(() => {
-    if (publicKey) {
-      fetchRecords(publicKey).then((data) => {
-        reset();
-        if (data) setRecords(data.records || []);
-      });
-    }
+  const load = useCallback(() => {
+    if (!publicKey) return;
+    fetchRecords(publicKey).then((data) => {
+      reset();
+      if (data) setRecords(data.records || []);
+    });
   }, [publicKey, fetchRecords]);
+
+  useEffect(() => { load(); }, [load]);
 
   if (!publicKey) {
     return (
@@ -50,9 +52,19 @@ export default function PatientDashboard() {
       </div>
       <p style={{ color: '#64748b', fontSize: '0.85rem', marginBottom: '1.5rem' }}>Wallet: {publicKey}</p>
 
-      {loading && <p style={{ color: '#94a3b8' }}>Loading…</p>}
-      {error && <p style={{ color: '#f87171' }}>Error: {error}</p>}
-      {!loading && total === 0 && <p style={{ color: '#94a3b8' }}>No vaccination records found.</p>}
+      {loading && <NFTCardSkeleton count={3} />}
+      {!loading && error && (
+        <div style={{ textAlign: 'center', padding: '2rem 0' }}>
+          <p style={{ color: '#f87171', marginBottom: '0.75rem' }}>⚠️ {error}</p>
+          <button style={styles.btn} onClick={load}>Retry</button>
+        </div>
+      )}
+      {!loading && !error && total === 0 && (
+        <div style={{ textAlign: 'center', padding: '3rem 0', color: '#475569' }}>
+          <p style={{ fontSize: '2rem', marginBottom: '0.5rem' }}>💉</p>
+          <p>No vaccination records found for this wallet.</p>
+        </div>
+      )}
 
       {currentItems.map((r) => <NFTCard key={r.token_id} record={r} />)}
 


### PR DESCRIPTION
 NFTCard loading states: skeleton, error retry, and empty state
  
  NFTCard.jsx previously rendered nothing on failed contract reads, giving users no feedback. This change adds proper
  loading, error, and empty states to the Patient Dashboard.
  
  Changes:
  
  - NFTCardSkeleton.jsx — new pulsing placeholder component that mirrors the NFTCard layout, shown while records are
  fetching
  - PatientDashboard.jsx — replaced plain text states with:
    - Skeleton loader (3 cards) while fetching
    - Error message with a Retry button on failure
    - Styled empty state when the wallet has no records

closes #2 