### PR TITLE
feat: add ErrorBoundary and toast notifications

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,23 +4,26 @@ import PatientDashboard from './pages/PatientDashboard';
 import IssuerDashboard from './pages/IssuerDashboard';
 import VerifyPage from './pages/VerifyPage';
 import { AuthProvider } from './hooks/useFreighter';
+import { ToastProvider } from './hooks/useToast';
 
 export default function App() {
   return (
-    <AuthProvider>
-      <nav style={{ padding: '1rem 2rem', background: '#1e293b', display: 'flex', gap: '1.5rem', alignItems: 'center' }}>
-        <strong style={{ color: '#38bdf8', fontSize: '1.2rem' }}>💉 VacciChain</strong>
-        <Link to="/">Home</Link>
-        <Link to="/patient">My Records</Link>
-        <Link to="/issuer">Issue</Link>
-        <Link to="/verify">Verify</Link>
-      </nav>
-      <Routes>
-        <Route path="/" element={<Landing />} />
-        <Route path="/patient" element={<PatientDashboard />} />
-        <Route path="/issuer" element={<IssuerDashboard />} />
-        <Route path="/verify" element={<VerifyPage />} />
-      </Routes>
-    </AuthProvider>
+    <ToastProvider>
+      <AuthProvider>
+        <nav style={{ padding: '1rem 2rem', background: '#1e293b', display: 'flex', gap: '1.5rem', alignItems: 'center' }}>
+          <strong style={{ color: '#38bdf8', fontSize: '1.2rem' }}>💉 VacciChain</strong>
+          <Link to="/">Home</Link>
+          <Link to="/patient">My Records</Link>
+          <Link to="/issuer">Issue</Link>
+          <Link to="/verify">Verify</Link>
+        </nav>
+        <Routes>
+          <Route path="/" element={<Landing />} />
+          <Route path="/patient" element={<PatientDashboard />} />
+          <Route path="/issuer" element={<IssuerDashboard />} />
+          <Route path="/verify" element={<VerifyPage />} />
+        </Routes>
+      </AuthProvider>
+    </ToastProvider>
   );
 }

--- a/frontend/src/components/ErrorBoundary.jsx
+++ b/frontend/src/components/ErrorBoundary.jsx
@@ -1,0 +1,35 @@
+import { Component } from 'react';
+
+export default class ErrorBoundary extends Component {
+  state = { error: null };
+
+  static getDerivedStateFromError(error) {
+    return { error };
+  }
+
+  componentDidCatch(error, info) {
+    if (import.meta.env.DEV) {
+      console.error('[ErrorBoundary]', error, info.componentStack);
+    }
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ maxWidth: 500, margin: '4rem auto', padding: '2rem', textAlign: 'center' }}>
+          <h2 style={{ color: '#f87171', marginBottom: '0.75rem' }}>Something went wrong</h2>
+          <p style={{ color: '#94a3b8', marginBottom: '1.5rem' }}>
+            {this.state.error.message || 'An unexpected error occurred.'}
+          </p>
+          <button
+            style={{ padding: '0.6rem 1.5rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 8, cursor: 'pointer' }}
+            onClick={() => this.setState({ error: null })}
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/frontend/src/hooks/useFreighter.js
+++ b/frontend/src/hooks/useFreighter.js
@@ -1,29 +1,23 @@
-import { createContext, useContext, useState, useCallback, useEffect } from 'react';
+import { createContext, useContext, useState, useCallback, useEffect, useRef } from 'react';
 import {
   isConnected,
   getPublicKey,
   signTransaction,
 } from '@stellar/freighter-api';
+import { useToast } from './useToast';
 
 const AuthContext = createContext(null);
 const STORAGE_KEY = 'vaccichain_wallet';
 
 export function AuthProvider({ children }) {
+  const toast = useToast();
   const [publicKey, setPublicKey] = useState(null);
   const [token, setToken] = useState(null);
   const [role, setRole] = useState(null);
   const [freighterInstalled, setFreighterInstalled] = useState(true);
+  const tokenRef = useRef(null);
 
-  const connect = useCallback(async () => {
-    const connected = await isConnected();
-    if (!connected) {
-      setFreighterInstalled(false);
-      throw new Error('Freighter wallet not found. Please install it.');
-    }
-
-    const pk = await getPublicKey();
-
-    // SEP-10 flow
+  const runSep10 = useCallback(async (pk) => {
     const challengeRes = await fetch('/auth/sep10', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -42,17 +36,26 @@ export function AuthProvider({ children }) {
   }, []);
 
   const connect = useCallback(async () => {
-    const connected = await isConnected();
-    if (!connected) throw new Error('Freighter wallet not found. Please install it.');
-    const pk = await getPublicKey();
-    const data = await runSep10(pk);
-    setPublicKey(pk);
-    setToken(data.token);
-    tokenRef.current = data.token;
-    setRole(data.role);
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ publicKey: pk, token: data.token, role: data.role }));
-    return data;
-  }, [runSep10]);
+    try {
+      const connected = await isConnected();
+      if (!connected) {
+        setFreighterInstalled(false);
+        throw new Error('Freighter wallet not found. Please install it.');
+      }
+      const pk = await getPublicKey();
+      const data = await runSep10(pk);
+      setPublicKey(pk);
+      setToken(data.token);
+      tokenRef.current = data.token;
+      setRole(data.role);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ publicKey: pk, token: data.token, role: data.role }));
+      toast('Wallet connected.', 'success');
+      return data;
+    } catch (e) {
+      toast(e.message || 'Failed to connect wallet.', 'error');
+      throw e;
+    }
+  }, [runSep10, toast]);
 
   const disconnect = useCallback(() => {
     setPublicKey(null);
@@ -66,9 +69,7 @@ export function AuthProvider({ children }) {
   useEffect(() => {
     const saved = localStorage.getItem(STORAGE_KEY);
     if (!saved) return;
-
     const { publicKey: savedKey, token: savedToken, role: savedRole } = JSON.parse(saved);
-
     isConnected().then((connected) => {
       if (!connected) {
         setFreighterInstalled(false);
@@ -77,11 +78,11 @@ export function AuthProvider({ children }) {
       }
       setPublicKey(savedKey);
       setToken(savedToken);
+      tokenRef.current = savedToken;
       setRole(savedRole);
     }).catch(() => localStorage.removeItem(STORAGE_KEY));
   }, []);
 
-  // Fetch wrapper: on 401, re-runs SEP-10 silently and retries once
   const apiFetch = useCallback(async (url, options = {}) => {
     const doFetch = (t) => fetch(url, {
       ...options,
@@ -103,7 +104,7 @@ export function AuthProvider({ children }) {
   }, [runSep10]);
 
   return (
-    <AuthContext.Provider value={{ publicKey, token, role, freighterInstalled, connect, disconnect }}>
+    <AuthContext.Provider value={{ publicKey, token, role, freighterInstalled, connect, disconnect, apiFetch }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/hooks/useToast.jsx
+++ b/frontend/src/hooks/useToast.jsx
@@ -1,0 +1,61 @@
+import { createContext, useContext, useState, useCallback } from 'react';
+
+const ToastContext = createContext(null);
+
+let _id = 0;
+
+export function ToastProvider({ children }) {
+  const [toasts, setToasts] = useState([]);
+
+  const toast = useCallback((message, type = 'info') => {
+    const id = ++_id;
+    setToasts((t) => [...t, { id, message, type }]);
+    setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 4000);
+  }, []);
+
+  return (
+    <ToastContext.Provider value={toast}>
+      {children}
+      <ToastList toasts={toasts} onDismiss={(id) => setToasts((t) => t.filter((x) => x.id !== id))} />
+    </ToastContext.Provider>
+  );
+}
+
+function ToastList({ toasts, onDismiss }) {
+  if (!toasts.length) return null;
+  return (
+    <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', display: 'flex', flexDirection: 'column', gap: '0.5rem', zIndex: 9999 }}>
+      {toasts.map((t) => (
+        <div
+          key={t.id}
+          role="alert"
+          style={{
+            padding: '0.75rem 1rem',
+            borderRadius: 8,
+            color: '#fff',
+            fontSize: '0.9rem',
+            maxWidth: 320,
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '0.75rem',
+            background: t.type === 'success' ? '#16a34a' : t.type === 'error' ? '#dc2626' : '#0ea5e9',
+          }}
+        >
+          <span>{t.message}</span>
+          <button
+            onClick={() => onDismiss(t.id)}
+            aria-label="Dismiss"
+            style={{ background: 'none', border: 'none', color: '#fff', cursor: 'pointer', fontSize: '1rem', lineHeight: 1 }}
+          >
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function useToast() {
+  return useContext(ToastContext);
+}

--- a/frontend/src/hooks/useVaccination.js
+++ b/frontend/src/hooks/useVaccination.js
@@ -1,30 +1,29 @@
 import { useState, useCallback } from 'react';
 import { useAuth } from './useFreighter';
+import { useToast } from './useToast';
 
 export function useVaccination() {
   const { apiFetch } = useAuth();
+  const toast = useToast();
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
 
   const fetchRecords = useCallback(async (wallet) => {
     setLoading(true);
-    setError(null);
     try {
       const res = await apiFetch(`/vaccination/${wallet}`);
       const data = await res.json();
       if (!res.ok) throw new Error(data.error);
       return data;
     } catch (e) {
-      setError(e.message);
+      toast(e.message || 'Failed to fetch records.', 'error');
       return null;
     } finally {
       setLoading(false);
     }
-  }, [apiFetch]);
+  }, [apiFetch, toast]);
 
   const issueVaccination = useCallback(async (payload) => {
     setLoading(true);
-    setError(null);
     try {
       const res = await apiFetch('/vaccination/issue', {
         method: 'POST',
@@ -33,14 +32,15 @@ export function useVaccination() {
       });
       const data = await res.json();
       if (!res.ok) throw new Error(data.error);
+      toast(`Vaccination NFT minted! Token ID: ${data.token_id}`, 'success');
       return data;
     } catch (e) {
-      setError(e.message);
+      toast(e.message || 'Failed to issue vaccination.', 'error');
       return null;
     } finally {
       setLoading(false);
     }
-  }, [apiFetch]);
+  }, [apiFetch, toast]);
 
-  return { fetchRecords, issueVaccination, loading, error };
+  return { fetchRecords, issueVaccination, loading };
 }

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import App from './App';
+import ErrorBoundary from './components/ErrorBoundary';
 import './index.css';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <BrowserRouter>
-      <App />
+      <ErrorBoundary>
+        <App />
+      </ErrorBoundary>
     </BrowserRouter>
   </React.StrictMode>
 );

--- a/frontend/src/pages/IssuerDashboard.jsx
+++ b/frontend/src/pages/IssuerDashboard.jsx
@@ -15,7 +15,7 @@ const EMPTY_FORM = { patient_address: '', vaccine_name: '', date_administered: '
 
 export default function IssuerDashboard() {
   const { publicKey, role, connect } = useAuth();
-  const { issueVaccination, loading, error } = useVaccination();
+  const { issueVaccination, loading } = useVaccination();
 
   const [form, setForm] = useState(() => {
     try {
@@ -25,9 +25,7 @@ export default function IssuerDashboard() {
       return EMPTY_FORM;
     }
   });
-  const [success, setSuccess] = useState(null);
 
-  // Persist form draft on every change
   useEffect(() => {
     sessionStorage.setItem(FORM_KEY, JSON.stringify(form));
   }, [form]);
@@ -47,10 +45,8 @@ export default function IssuerDashboard() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    setSuccess(null);
     const result = await issueVaccination(form);
     if (result) {
-      setSuccess(`Vaccination NFT minted! Token ID: ${result.token_id}`);
       setForm(EMPTY_FORM);
       sessionStorage.removeItem(FORM_KEY);
     }
@@ -80,8 +76,6 @@ export default function IssuerDashboard() {
           {loading ? 'Minting…' : 'Issue Vaccination NFT'}
         </button>
       </form>
-      {error && <p style={{ color: '#f87171', marginTop: '1rem' }}>Error: {error}</p>}
-      {success && <p style={{ color: '#4ade80', marginTop: '1rem' }}>✅ {success}</p>}
     </div>
   );
 }

--- a/frontend/src/pages/PatientDashboard.jsx
+++ b/frontend/src/pages/PatientDashboard.jsx
@@ -18,7 +18,7 @@ const styles = {
 
 export default function PatientDashboard() {
   const { publicKey, connect } = useAuth();
-  const { fetchRecords, loading, error } = useVaccination();
+  const { fetchRecords, loading } = useVaccination();
   const [records, setRecords] = useState([]);
   const { currentItems, page, totalPages, goTo, reset, total } = usePagination(records);
 
@@ -51,7 +51,6 @@ export default function PatientDashboard() {
       <p style={{ color: '#64748b', fontSize: '0.85rem', marginBottom: '1.5rem' }}>Wallet: {publicKey}</p>
 
       {loading && <p style={{ color: '#94a3b8' }}>Loading…</p>}
-      {error && <p style={{ color: '#f87171' }}>Error: {error}</p>}
       {!loading && total === 0 && <p style={{ color: '#94a3b8' }}>No vaccination records found.</p>}
 
       {currentItems.map((r) => <NFTCard key={r.token_id} record={r} />)}

--- a/frontend/src/pages/VerifyPage.jsx
+++ b/frontend/src/pages/VerifyPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import VerificationBadge from '../components/VerificationBadge';
 import NFTCard from '../components/NFTCard';
+import { useToast } from '../hooks/useToast';
 
 const styles = {
   page: { maxWidth: 600, margin: '2rem auto', padding: '0 1rem' },
@@ -9,15 +10,14 @@ const styles = {
 };
 
 export default function VerifyPage() {
+  const toast = useToast();
   const [wallet, setWallet] = useState('');
   const [result, setResult] = useState(null);
   const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(null);
 
   const handleVerify = async (e) => {
     e.preventDefault();
     setLoading(true);
-    setError(null);
     setResult(null);
     try {
       const res = await fetch(`/verify/${wallet.trim()}`);
@@ -25,7 +25,7 @@ export default function VerifyPage() {
       if (!res.ok) throw new Error(data.error);
       setResult(data);
     } catch (e) {
-      setError(e.message);
+      toast(e.message || 'Verification failed.', 'error');
     } finally {
       setLoading(false);
     }
@@ -46,8 +46,6 @@ export default function VerifyPage() {
           {loading ? 'Checking…' : 'Verify'}
         </button>
       </form>
-
-      {error && <p style={{ color: '#f87171', marginTop: '1rem' }}>Error: {error}</p>}
 
       {result && (
         <div style={{ marginTop: '1.5rem' }}>


### PR DESCRIPTION
Add ErrorBoundary and toast notifications
  
  Prevents unhandled React errors from crashing the entire app and adds user-visible feedback for all async actions.
  
  Changes
  
  - ErrorBoundary component wraps the app root — catches render errors and shows a fallback UI with a "Try again"
  button
  - useToast hook + ToastProvider — lightweight toast system (no new dependency), auto-dismisses after 4s, supports
  success / error / info types
  - useVaccination — removed local error state; errors and mint success now surface via toast
  - useFreighter — toasts on wallet connect success/failure; fixed duplicate connect definition
  - Pages (IssuerDashboard, PatientDashboard, VerifyPage) — removed inline error/success <p> tags, feedback handled by
  toast
  - Error logging via console.error in dev only (import.meta.env.DEV), suppressed in prod
  
  Testing
  
  - Trigger a contract call failure → error toast appears
  - Successful mint → success toast with token ID
  - Force a render error → ErrorBoundary fallback renders, "Try again" resets it

closes #6 