### PR TITLE
fix: add client-side validation to vaccination issue form

### DIFF
--- a/frontend/src/pages/IssuerDashboard.jsx
+++ b/frontend/src/pages/IssuerDashboard.jsx
@@ -6,9 +6,28 @@ const styles = {
   page: { maxWidth: 500, margin: '2rem auto', padding: '0 1rem' },
   form: { display: 'flex', flexDirection: 'column', gap: '1rem' },
   input: { padding: '0.6rem 0.75rem', background: '#1e293b', border: '1px solid #334155', borderRadius: 8, color: '#e2e8f0', fontSize: '1rem' },
+  inputError: { padding: '0.6rem 0.75rem', background: '#1e293b', border: '1px solid #f87171', borderRadius: 8, color: '#e2e8f0', fontSize: '1rem' },
   btn: { padding: '0.7rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 8, fontSize: '1rem' },
+  btnDisabled: { padding: '0.7rem', background: '#334155', color: '#64748b', border: 'none', borderRadius: 8, fontSize: '1rem', cursor: 'not-allowed' },
   label: { color: '#94a3b8', fontSize: '0.85rem', marginBottom: '0.25rem' },
+  fieldError: { color: '#f87171', fontSize: '0.78rem', marginTop: '0.25rem' },
 };
+
+const STELLAR_ADDRESS_RE = /^G[A-Z2-7]{55}$/;
+const today = () => new Date().toISOString().split('T')[0];
+
+function validate(form) {
+  const errors = {};
+  if (!STELLAR_ADDRESS_RE.test(form.patient_address))
+    errors.patient_address = 'Must be a valid Stellar public key (G…, 56 chars)';
+  if (!form.vaccine_name.trim())
+    errors.vaccine_name = 'Vaccine name is required';
+  if (!form.date_administered)
+    errors.date_administered = 'Date is required';
+  else if (form.date_administered > today())
+    errors.date_administered = 'Date cannot be in the future';
+  return errors;
+}
 
 const FORM_KEY = 'issuer_form_draft';
 const EMPTY_FORM = { patient_address: '', vaccine_name: '', date_administered: '' };
@@ -25,7 +44,11 @@ export default function IssuerDashboard() {
       return EMPTY_FORM;
     }
   });
+  const [touched, setTouched] = useState({});
   const [success, setSuccess] = useState(null);
+
+  const errors = validate(form);
+  const isValid = Object.keys(errors).length === 0;
 
   // Persist form draft on every change
   useEffect(() => {
@@ -56,27 +79,39 @@ export default function IssuerDashboard() {
     }
   };
 
+  const fields = [
+    { key: 'patient_address', label: 'Patient Stellar Address', placeholder: 'G...', type: 'text' },
+    { key: 'vaccine_name', label: 'Vaccine Name', placeholder: 'e.g. COVID-19', type: 'text' },
+    { key: 'date_administered', label: 'Date Administered', placeholder: '', type: 'date' },
+  ];
+
   return (
     <div style={styles.page}>
       <h2 style={{ marginBottom: '1.5rem', color: '#e2e8f0' }}>Issue Vaccination NFT</h2>
       <form style={styles.form} onSubmit={handleSubmit}>
-        {[
-          { key: 'patient_address', label: 'Patient Stellar Address', placeholder: 'G...' },
-          { key: 'vaccine_name', label: 'Vaccine Name', placeholder: 'e.g. COVID-19' },
-          { key: 'date_administered', label: 'Date Administered', placeholder: 'YYYY-MM-DD' },
-        ].map(({ key, label, placeholder }) => (
-          <div key={key}>
-            <p style={styles.label}>{label}</p>
-            <input
-              style={styles.input}
-              placeholder={placeholder}
-              value={form[key]}
-              onChange={(e) => setForm((f) => ({ ...f, [key]: e.target.value }))}
-              required
-            />
-          </div>
-        ))}
-        <button style={styles.btn} type="submit" disabled={loading}>
+        {fields.map(({ key, label, placeholder, type }) => {
+          const hasError = touched[key] && errors[key];
+          return (
+            <div key={key}>
+              <p style={styles.label}>{label}</p>
+              <input
+                style={hasError ? styles.inputError : styles.input}
+                type={type}
+                placeholder={placeholder}
+                value={form[key]}
+                max={key === 'date_administered' ? today() : undefined}
+                onChange={(e) => setForm((f) => ({ ...f, [key]: e.target.value }))}
+                onBlur={() => setTouched((t) => ({ ...t, [key]: true }))}
+              />
+              {hasError && <p style={styles.fieldError}>{errors[key]}</p>}
+            </div>
+          );
+        })}
+        <button
+          style={isValid && !loading ? styles.btn : styles.btnDisabled}
+          type="submit"
+          disabled={!isValid || loading}
+        >
           {loading ? 'Minting…' : 'Issue Vaccination NFT'}
         </button>
       </form>


### PR DESCRIPTION
Closes #5

---

## Summary
Adds client-side validation to the IssuerDashboard form so invalid data never reaches the backend.

## Changes
- Stellar public key regex validation (G…, 56 chars, base32 alphabet)
- Vaccine name required check (trims whitespace)
- Date required + future date blocked via both `max` attribute and validate function
- Inline error messages shown on blur (touched state)
- Red border on invalid fields
- Submit button disabled until all fields are valid

## Tested
- Invalid Stellar address shows error and blocks submit
- Empty vaccine name shows error and blocks submit
- Future date shows error and blocks submit
- Valid form enables submit and mints successfully