### PR TITLE
fix: responsive layout for mobile screens

### DIFF
--- a/frontend/src/components/NFTCard.jsx
+++ b/frontend/src/components/NFTCard.jsx
@@ -13,15 +13,18 @@ export default function NFTCard({ record, onClick }) {
         marginBottom: '1rem',
         cursor: 'pointer',
         transition: 'border-color 0.15s',
+        width: '100%',
+        boxSizing: 'border-box',
+        minWidth: 0,
       }}
       onMouseEnter={(e) => (e.currentTarget.style.borderColor = '#38bdf8')}
       onMouseLeave={(e) => (e.currentTarget.style.borderColor = '#334155')}
     >
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-        <span style={{ fontSize: '1.1rem', fontWeight: 600, color: '#38bdf8' }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', alignItems: 'center', gap: '0.5rem' }}>
+        <span style={{ fontSize: '1.1rem', fontWeight: 600, color: '#38bdf8', minWidth: 0, wordBreak: 'break-word' }}>
           💉 {record.vaccine_name}
         </span>
-        <span style={{ fontSize: '0.75rem', color: '#64748b' }}>#{record.token_id}</span>
+        <span style={{ fontSize: '0.75rem', color: '#64748b', whiteSpace: 'nowrap' }}>#{record.token_id}</span>
       </div>
       <p style={{ color: '#94a3b8', marginTop: '0.5rem', fontSize: '0.9rem' }}>
         Date: {record.date_administered}

--- a/frontend/src/pages/IssuerDashboard.jsx
+++ b/frontend/src/pages/IssuerDashboard.jsx
@@ -3,12 +3,12 @@ import { useAuth } from '../hooks/useFreighter';
 import { useVaccination } from '../hooks/useVaccination';
 
 const styles = {
-  page: { maxWidth: 500, margin: '2rem auto', padding: '0 1rem' },
+  page: { maxWidth: 500, width: '100%', margin: '2rem auto', padding: '0 1rem', boxSizing: 'border-box' },
   form: { display: 'flex', flexDirection: 'column', gap: '1rem' },
-  input: { padding: '0.6rem 0.75rem', background: '#1e293b', border: '1px solid #334155', borderRadius: 8, color: '#e2e8f0', fontSize: '1rem' },
-  inputError: { padding: '0.6rem 0.75rem', background: '#1e293b', border: '1px solid #f87171', borderRadius: 8, color: '#e2e8f0', fontSize: '1rem' },
-  btn: { padding: '0.7rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 8, fontSize: '1rem' },
-  btnDisabled: { padding: '0.7rem', background: '#334155', color: '#64748b', border: 'none', borderRadius: 8, fontSize: '1rem', cursor: 'not-allowed' },
+  input: { padding: '0.6rem 0.75rem', background: '#1e293b', border: '1px solid #334155', borderRadius: 8, color: '#e2e8f0', fontSize: '1rem', width: '100%', boxSizing: 'border-box' },
+  inputError: { padding: '0.6rem 0.75rem', background: '#1e293b', border: '1px solid #f87171', borderRadius: 8, color: '#e2e8f0', fontSize: '1rem', width: '100%', boxSizing: 'border-box' },
+  btn: { padding: '0.7rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 8, fontSize: '1rem', width: '100%', touchAction: 'manipulation' },
+  btnDisabled: { padding: '0.7rem', background: '#334155', color: '#64748b', border: 'none', borderRadius: 8, fontSize: '1rem', cursor: 'not-allowed', width: '100%' },
   label: { color: '#94a3b8', fontSize: '0.85rem', marginBottom: '0.25rem' },
   fieldError: { color: '#f87171', fontSize: '0.78rem', marginTop: '0.25rem' },
 };

--- a/frontend/src/pages/PatientDashboard.jsx
+++ b/frontend/src/pages/PatientDashboard.jsx
@@ -6,9 +6,9 @@ import NFTCard from '../components/NFTCard';
 import RecordDetailModal from '../components/RecordDetailModal';
 
 const styles = {
-  page: { maxWidth: 700, margin: '2rem auto', padding: '0 1rem' },
+  page: { maxWidth: 700, width: '100%', margin: '2rem auto', padding: '0 1rem', boxSizing: 'border-box' },
   btn: { padding: '0.6rem 1.5rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 8, cursor: 'pointer' },
-  controls: { display: 'flex', alignItems: 'center', gap: '0.75rem', marginTop: '1.25rem' },
+  controls: { display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: '0.75rem', marginTop: '1.25rem' },
   pageBtn: {
     padding: '0.4rem 0.9rem', background: '#1e293b', color: '#e2e8f0',
     border: '1px solid #334155', borderRadius: 6, cursor: 'pointer',
@@ -42,13 +42,13 @@ export default function PatientDashboard() {
 
   return (
     <div style={styles.page}>
-      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'baseline', marginBottom: '1.5rem' }}>
+      <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'space-between', alignItems: 'baseline', gap: '0.5rem', marginBottom: '1.5rem' }}>
         <h2 style={{ color: '#e2e8f0', margin: 0 }}>My Vaccination Records</h2>
         {total > 0 && (
           <span style={{ color: '#64748b', fontSize: '0.85rem' }}>{total} record{total !== 1 ? 's' : ''}</span>
         )}
       </div>
-      <p style={{ color: '#64748b', fontSize: '0.85rem', marginBottom: '1.5rem' }}>Wallet: {publicKey}</p>
+      <p style={{ color: '#64748b', fontSize: '0.85rem', marginBottom: '1.5rem', wordBreak: 'break-all' }}>Wallet: {publicKey}</p>
 
       {loading && <p style={{ color: '#94a3b8' }}>Loading…</p>}
       {error && <p style={{ color: '#f87171' }}>Error: {error}</p>}


### PR DESCRIPTION
Closes #3

---

## Summary
Fixes layout overflow on PatientDashboard and IssuerDashboard at 375px, 768px, and 1280px.

## Changes
- **PatientDashboard**: header row wraps on mobile (`flexWrap`), wallet address breaks on overflow (`wordBreak: break-all`), pagination controls wrap
- **NFTCard**: card is full-width (`width: 100%`), vaccine name/token ID row wraps, long names break cleanly
- **IssuerDashboard**: inputs and buttons are full-width (`width: 100%`), `boxSizing: border-box` prevents horizontal scroll, button has `touchAction: manipulation` for touch devices

## Acceptance Criteria
- ✅ Layout usable at 375px, 768px, 1280px — no horizontal scroll
- ✅ NFT card reflows to single column on mobile (already single-column, now properly constrained)
- ✅ Forms usable on touch devices without horizontal scroll