### PR TITLE
Feat/event indexing

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -12,7 +12,9 @@
         "cors": "^2.8.5",
         "dotenv": "^16.3.1",
         "express": "^4.18.2",
+        "express-rate-limit": "^7.2.0",
         "jsonwebtoken": "^9.0.2",
+        "sql.js": "^1.12.0",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -2379,13 +2381,10 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
-      "integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.2.0.tgz",
+      "integrity": "sha512-T7nul1t4TNyfZMJ7pKRKkdeVJWa2CqB8NA1P8BwYaoDI5QSBZARv5oMS43J7b7I5P+4asjVXjb7ONuwDKucahg==",
       "license": "MIT",
-      "dependencies": {
-        "ip-address": "10.1.0"
-      },
       "engines": {
         "node": ">= 16"
       },
@@ -2393,7 +2392,7 @@
         "url": "https://github.com/sponsors/express-rate-limit"
       },
       "peerDependencies": {
-        "express": ">= 4.11"
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -2899,15 +2898,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12"
-      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5088,6 +5078,12 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/sql.js": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.12.0.tgz",
+      "integrity": "sha512-Bi+43yMx/tUFZVYD4AUscmdL6NHn3gYQ+CM+YheFWLftOmrEC/Mz6Yh7E96Y2WDHYz3COSqT+LP6Z79zgrwJlA==",
+      "license": "MIT"
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,8 +12,15 @@
     "cors": "^2.8.5",
     "dotenv": "^16.3.1",
     "express": "^4.18.2",
+    "express-rate-limit": "^7.2.0",
     "jsonwebtoken": "^9.0.2",
+    "sql.js": "^1.12.0",
     "zod": "^4.3.6"
+  },
+  "jest": {
+    "setupFiles": [
+      "./tests/setup.js"
+    ]
   },
   "devDependencies": {
     "jest": "^29.7.0",

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -1,11 +1,14 @@
 require('dotenv').config();
-require('./config');
+const config = require('./config');
 const express = require('express');
 const cors = require('cors');
 
 const authRoutes = require('./routes/auth');
 const vaccinationRoutes = require('./routes/vaccination');
 const verifyRoutes = require('./routes/verify');
+const eventsRoutes = require('./routes/events');
+const { initDb } = require('./indexer/db');
+const { startPoller } = require('./indexer/poller');
 
 const app = express();
 
@@ -15,12 +18,15 @@ app.use(express.json());
 app.use('/auth', authRoutes);
 app.use('/vaccination', vaccinationRoutes);
 app.use('/verify', verifyRoutes);
+app.use('/events', eventsRoutes);
 
 app.get('/health', (_req, res) => res.json({ status: 'ok' }));
 
-const PORT = process.env.PORT || 4000;
 if (require.main === module) {
-  app.listen(PORT, () => console.log(`Backend running on port ${PORT}`));
+  initDb(config.DATABASE_PATH).then(() => {
+    startPoller(config.EVENT_POLL_INTERVAL_MS);
+    app.listen(config.PORT, () => console.log(`Backend running on port ${config.PORT}`));
+  });
 }
 
 module.exports = app;

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -15,6 +15,10 @@ const schema = z.object({
   SEP10_SERVER_KEY: z.string().min(1),
   JWT_SECRET: z.string().min(1),
   PORT: z.coerce.number().int().positive().default(4000),
+
+  // Indexer
+  EVENT_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(15000),
+  DATABASE_PATH: z.string().default('/data/vaccichain.db'),
 });
 
 const result = schema.safeParse(process.env);

--- a/backend/src/indexer/db.js
+++ b/backend/src/indexer/db.js
@@ -1,0 +1,99 @@
+/**
+ * SQLite-backed event store using sql.js (pure WASM — no native build required).
+ * The DB is loaded from disk on init and flushed to disk after every write.
+ */
+const initSqlJs = require('sql.js');
+const fs = require('fs');
+const path = require('path');
+
+let db = null;
+let dbPath = null;
+
+const SCHEMA = `
+  CREATE TABLE IF NOT EXISTS events (
+    id          TEXT PRIMARY KEY,
+    event_type  TEXT NOT NULL,
+    ledger      INTEGER NOT NULL,
+    timestamp   INTEGER NOT NULL,
+    contract_id TEXT NOT NULL,
+    payload     TEXT NOT NULL
+  );
+  CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);
+  CREATE INDEX IF NOT EXISTS idx_events_ledger ON events(ledger);
+`;
+
+/** Persist in-memory DB to disk. */
+function flush() {
+  if (!db || !dbPath) return;
+  const data = db.export();
+  fs.writeFileSync(dbPath, Buffer.from(data));
+}
+
+/** Initialize (or load) the database. */
+async function initDb(filePath) {
+  dbPath = filePath;
+  const SQL = await initSqlJs();
+
+  if (fs.existsSync(filePath)) {
+    const fileBuffer = fs.readFileSync(filePath);
+    db = new SQL.Database(fileBuffer);
+  } else {
+    db = new SQL.Database();
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  }
+
+  db.run(SCHEMA);
+  flush();
+  return db;
+}
+
+/**
+ * Upsert a batch of events. Deduplicates by id (PRIMARY KEY conflict = ignore).
+ * @param {Array<{id, event_type, ledger, timestamp, contract_id, payload}>} events
+ */
+function upsertEvents(events) {
+  if (!events.length) return;
+  const stmt = db.prepare(
+    'INSERT OR IGNORE INTO events (id, event_type, ledger, timestamp, contract_id, payload) VALUES (?,?,?,?,?,?)'
+  );
+  for (const e of events) {
+    stmt.run([e.id, e.event_type, e.ledger, e.timestamp, e.contract_id, JSON.stringify(e.payload)]);
+  }
+  stmt.free();
+  flush();
+}
+
+/**
+ * Query events with optional filters.
+ * @param {{ event_type?: string, limit?: number, offset?: number }} opts
+ */
+function queryEvents({ event_type, limit = 100, offset = 0 } = {}) {
+  let sql = 'SELECT * FROM events';
+  const params = [];
+  if (event_type) {
+    sql += ' WHERE event_type = ?';
+    params.push(event_type);
+  }
+  sql += ' ORDER BY ledger DESC LIMIT ? OFFSET ?';
+  params.push(limit, offset);
+
+  const results = db.exec(sql, params);
+  if (!results.length) return [];
+
+  const { columns, values } = results[0];
+  return values.map((row) => {
+    const obj = {};
+    columns.forEach((col, i) => { obj[col] = row[i]; });
+    obj.payload = JSON.parse(obj.payload);
+    return obj;
+  });
+}
+
+/** Return the highest ledger sequence we've indexed (0 if none). */
+function getLatestLedger() {
+  const res = db.exec('SELECT MAX(ledger) as max_ledger FROM events');
+  if (!res.length || res[0].values[0][0] == null) return 0;
+  return res[0].values[0][0];
+}
+
+module.exports = { initDb, upsertEvents, queryEvents, getLatestLedger };

--- a/backend/src/indexer/poller.js
+++ b/backend/src/indexer/poller.js
@@ -1,0 +1,106 @@
+/**
+ * Polls the Soroban RPC for contract events and stores them in SQLite.
+ *
+ * Soroban RPC: getEvents({ startLedger, filters: [{ contractIds, topics }] })
+ * Indexed event types: VaccinationMinted, IssuerAdded, IssuerRevoked
+ */
+const StellarSdk = require('@stellar/stellar-sdk');
+const { upsertEvents, getLatestLedger } = require('./db');
+
+const SOROBAN_RPC_URL = process.env.SOROBAN_RPC_URL || 'https://soroban-testnet.stellar.org';
+const CONTRACT_ID = process.env.VACCINATIONS_CONTRACT_ID;
+
+// Map Soroban symbol_short event topic names to our internal event_type strings
+const TOPIC_MAP = {
+  minted:  'VaccinationMinted',
+  iss_add: 'IssuerAdded',
+  iss_rev: 'IssuerRevoked',
+};
+
+let timer = null;
+
+function getRpc() {
+  return new StellarSdk.SorobanRpc.Server(SOROBAN_RPC_URL);
+}
+
+/** Parse a raw Soroban event into our storage shape. Returns null if unrecognised. */
+function parseEvent(raw) {
+  try {
+    const topicVal = raw.topic?.[0];
+    if (!topicVal) return null;
+
+    // topic[0] is a ScVal symbol — extract the string value
+    const topicStr = topicVal.value?.toString?.() ?? topicVal.toString();
+    const event_type = TOPIC_MAP[topicStr];
+    if (!event_type) return null;
+
+    return {
+      id: raw.id,
+      event_type,
+      ledger: raw.ledger,
+      timestamp: raw.ledgerClosedAt
+        ? Math.floor(new Date(raw.ledgerClosedAt).getTime() / 1000)
+        : 0,
+      contract_id: raw.contractId ?? CONTRACT_ID,
+      payload: raw.value ?? {},
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function poll() {
+  if (!CONTRACT_ID) {
+    if (process.env.NODE_ENV !== 'test') {
+      console.warn('[indexer] VACCINATIONS_CONTRACT_ID not set — skipping poll');
+    }
+    return;
+  }
+
+  try {
+    const rpc = getRpc();
+    const startLedger = getLatestLedger() + 1;
+
+    const response = await rpc.getEvents({
+      startLedger,
+      filters: [{ contractIds: [CONTRACT_ID] }],
+    });
+
+    const events = (response.events ?? [])
+      .map(parseEvent)
+      .filter(Boolean);
+
+    if (events.length) {
+      upsertEvents(events);
+      if (process.env.NODE_ENV !== 'test') {
+        console.log(`[indexer] Stored ${events.length} new event(s) from ledger ${startLedger}`);
+      }
+    }
+  } catch (err) {
+    if (process.env.NODE_ENV !== 'test') {
+      console.error('[indexer] Poll error:', err.message);
+    }
+  }
+}
+
+/**
+ * Start the background polling loop.
+ * @param {number} intervalMs
+ */
+function startPoller(intervalMs) {
+  if (timer) return;
+  poll(); // immediate first run
+  timer = setInterval(poll, intervalMs);
+  if (process.env.NODE_ENV !== 'test') {
+    console.log(`[indexer] Polling every ${intervalMs}ms`);
+  }
+}
+
+function stopPoller() {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+}
+
+module.exports = { startPoller, stopPoller, poll, parseEvent };

--- a/backend/src/routes/events.js
+++ b/backend/src/routes/events.js
@@ -1,0 +1,19 @@
+const express = require('express');
+const { queryEvents } = require('../indexer/db');
+
+const router = express.Router();
+
+/**
+ * GET /events
+ * Query params: event_type, limit (max 500), offset
+ */
+router.get('/', (req, res) => {
+  const { event_type } = req.query;
+  const limit = Math.min(parseInt(req.query.limit) || 100, 500);
+  const offset = parseInt(req.query.offset) || 0;
+
+  const events = queryEvents({ event_type, limit, offset });
+  res.json({ events, count: events.length });
+});
+
+module.exports = router;

--- a/backend/tests/indexer.test.js
+++ b/backend/tests/indexer.test.js
@@ -1,0 +1,157 @@
+const os = require('os');
+const path = require('path');
+const fs = require('fs');
+const { initDb, upsertEvents, queryEvents, getLatestLedger } = require('../src/indexer/db');
+const { parseEvent, stopPoller } = require('../src/indexer/poller');
+
+const tmpDb = path.join(os.tmpdir(), `vaccichain-test-${Date.now()}.db`);
+
+beforeAll(async () => {
+  await initDb(tmpDb);
+});
+
+afterAll(() => {
+  stopPoller();
+  if (fs.existsSync(tmpDb)) fs.unlinkSync(tmpDb);
+});
+
+describe('db — upsertEvents / queryEvents', () => {
+  const sample = [
+    {
+      id: 'evt-001',
+      event_type: 'VaccinationMinted',
+      ledger: 100,
+      timestamp: 1700000000,
+      contract_id: 'CABC',
+      payload: { vaccine_name: 'COVID-19', issuer: 'GISSUER1' },
+    },
+    {
+      id: 'evt-002',
+      event_type: 'IssuerAdded',
+      ledger: 101,
+      timestamp: 1700000060,
+      contract_id: 'CABC',
+      payload: { issuer: 'GISSUER2' },
+    },
+  ];
+
+  it('stores events and returns them', () => {
+    upsertEvents(sample);
+    const results = queryEvents();
+    expect(results.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('deduplicates on re-insert', () => {
+    upsertEvents(sample); // insert same events again
+    const results = queryEvents({ event_type: 'VaccinationMinted' });
+    const ids = results.map((e) => e.id);
+    expect(ids.filter((id) => id === 'evt-001').length).toBe(1);
+  });
+
+  it('filters by event_type', () => {
+    const minted = queryEvents({ event_type: 'VaccinationMinted' });
+    expect(minted.every((e) => e.event_type === 'VaccinationMinted')).toBe(true);
+
+    const added = queryEvents({ event_type: 'IssuerAdded' });
+    expect(added.every((e) => e.event_type === 'IssuerAdded')).toBe(true);
+  });
+
+  it('deserialises payload back to object', () => {
+    const [evt] = queryEvents({ event_type: 'VaccinationMinted' });
+    expect(typeof evt.payload).toBe('object');
+    expect(evt.payload.vaccine_name).toBe('COVID-19');
+  });
+
+  it('getLatestLedger returns highest ledger', () => {
+    expect(getLatestLedger()).toBeGreaterThanOrEqual(101);
+  });
+
+  it('respects limit and offset', () => {
+    const first = queryEvents({ limit: 1, offset: 0 });
+    const second = queryEvents({ limit: 1, offset: 1 });
+    expect(first.length).toBe(1);
+    expect(second.length).toBe(1);
+    expect(first[0].id).not.toBe(second[0].id);
+  });
+});
+
+describe('poller — parseEvent', () => {
+  it('maps minted topic to VaccinationMinted', () => {
+    const raw = {
+      id: 'raw-001',
+      topic: [{ value: { toString: () => 'minted' } }],
+      ledger: 200,
+      ledgerClosedAt: '2024-01-01T00:00:00Z',
+      contractId: 'CABC',
+      value: { vaccine_name: 'Flu' },
+    };
+    const parsed = parseEvent(raw);
+    expect(parsed).not.toBeNull();
+    expect(parsed.event_type).toBe('VaccinationMinted');
+    expect(parsed.ledger).toBe(200);
+  });
+
+  it('maps iss_add topic to IssuerAdded', () => {
+    const raw = {
+      id: 'raw-002',
+      topic: [{ value: { toString: () => 'iss_add' } }],
+      ledger: 201,
+      ledgerClosedAt: '2024-01-01T00:01:00Z',
+      contractId: 'CABC',
+      value: {},
+    };
+    expect(parseEvent(raw).event_type).toBe('IssuerAdded');
+  });
+
+  it('maps iss_rev topic to IssuerRevoked', () => {
+    const raw = {
+      id: 'raw-003',
+      topic: [{ value: { toString: () => 'iss_rev' } }],
+      ledger: 202,
+      ledgerClosedAt: '2024-01-01T00:02:00Z',
+      contractId: 'CABC',
+      value: {},
+    };
+    expect(parseEvent(raw).event_type).toBe('IssuerRevoked');
+  });
+
+  it('returns null for unknown topic', () => {
+    const raw = {
+      id: 'raw-004',
+      topic: [{ value: { toString: () => 'unknown_event' } }],
+      ledger: 203,
+      ledgerClosedAt: '2024-01-01T00:03:00Z',
+      contractId: 'CABC',
+      value: {},
+    };
+    expect(parseEvent(raw)).toBeNull();
+  });
+
+  it('returns null when topic is missing', () => {
+    expect(parseEvent({ id: 'raw-005', ledger: 204 })).toBeNull();
+  });
+});
+
+describe('GET /events route', () => {
+  const request = require('supertest');
+  const app = require('../src/app');
+
+  it('returns events array', async () => {
+    const res = await request(app).get('/events');
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.events)).toBe(true);
+    expect(typeof res.body.count).toBe('number');
+  });
+
+  it('filters by event_type', async () => {
+    const res = await request(app).get('/events?event_type=VaccinationMinted');
+    expect(res.status).toBe(200);
+    res.body.events.forEach((e) => expect(e.event_type).toBe('VaccinationMinted'));
+  });
+
+  it('respects limit param', async () => {
+    const res = await request(app).get('/events?limit=1');
+    expect(res.status).toBe(200);
+    expect(res.body.events.length).toBeLessThanOrEqual(1);
+  });
+});

--- a/backend/tests/setup.js
+++ b/backend/tests/setup.js
@@ -1,0 +1,10 @@
+// Set required env vars before any module is loaded in tests
+process.env.STELLAR_NETWORK = 'testnet';
+process.env.HORIZON_URL = 'https://horizon-testnet.stellar.org';
+process.env.SOROBAN_RPC_URL = 'https://soroban-testnet.stellar.org';
+process.env.STELLAR_NETWORK_PASSPHRASE = 'Test SDF Network ; September 2015';
+process.env.VACCINATIONS_CONTRACT_ID = 'CTEST000000000000000000000000000000000000000000000000000';
+process.env.ADMIN_SECRET_KEY = 'STEST000000000000000000000000000000000000000000000000000';
+process.env.SEP10_SERVER_KEY = 'STEST000000000000000000000000000000000000000000000000001';
+process.env.JWT_SECRET = 'test-jwt-secret';
+process.env.NODE_ENV = 'test';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
     ports:
       - "4000:4000"
     env_file: .env
+    environment:
+      - EVENT_POLL_INTERVAL_MS=${EVENT_POLL_INTERVAL_MS:-15000}
+      - DATABASE_PATH=/data/vaccichain.db
+    volumes:
+      - vaccichain_db:/data
     depends_on:
       - python-service
     networks:
@@ -24,9 +29,13 @@ services:
       - "8001:8001"
     environment:
       - BACKEND_URL=http://backend:4000
+      - ANOMALY_THRESHOLD=${ANOMALY_THRESHOLD:-50}
     networks:
       - vaccichain
 
 networks:
   vaccichain:
     driver: bridge
+
+volumes:
+  vaccichain_db:

--- a/python-service/pytest.ini
+++ b/python-service/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+pythonpath = .

--- a/python-service/routes/analytics.py
+++ b/python-service/routes/analytics.py
@@ -1,57 +1,68 @@
 import os
-import httpx
+from collections import defaultdict
 from fastapi import APIRouter, HTTPException
-from collections import defaultdict, Counter
+import httpx
 
 router = APIRouter()
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://backend:4000")
+# Anomaly threshold: flag issuers with more than this many mints in the dataset
+ANOMALY_THRESHOLD = int(os.getenv("ANOMALY_THRESHOLD", "50"))
 
 
-async def _fetch_records(wallet: str) -> dict:
+async def _fetch_events(event_type: str, limit: int = 500) -> list:
     async with httpx.AsyncClient() as client:
-        res = await client.get(f"{BACKEND_URL}/verify/{wallet}", timeout=10)
+        res = await client.get(
+            f"{BACKEND_URL}/events",
+            params={"event_type": event_type, "limit": limit},
+            timeout=10,
+        )
         res.raise_for_status()
-        return res.json()
+        return res.json().get("events", [])
 
 
 @router.get("/rates")
 async def vaccination_rates():
-    """
-    Returns aggregated vaccination counts by vaccine type.
-    In production this would query an indexed event store.
-    This endpoint demonstrates the analytics shape.
-    """
-    # Placeholder: real implementation queries Horizon event stream
-    return {
-        "note": "Connect to Horizon event stream for live data",
-        "sample": {
-            "COVID-19": 1240,
-            "Influenza": 870,
-            "Hepatitis B": 430,
-        },
-    }
+    """Vaccination counts grouped by vaccine name, derived from indexed mint events."""
+    events = await _fetch_events("VaccinationMinted")
+    counts: dict[str, int] = defaultdict(int)
+    for e in events:
+        vaccine = e.get("payload", {}).get("vaccine_name") or e.get("payload", {}).get("1")
+        if vaccine:
+            counts[str(vaccine)] += 1
+    return {"rates": dict(counts), "total_mints": len(events)}
 
 
 @router.get("/issuers")
 async def issuer_activity():
-    """Issuer activity stats — volume and last active timestamp."""
-    return {
-        "note": "Derived from on-chain mint events",
-        "sample": [
-            {"issuer": "GABC...XYZ", "total_issued": 312, "last_active": "2024-03-15"},
-            {"issuer": "GDEF...UVW", "total_issued": 98, "last_active": "2024-03-10"},
-        ],
-    }
+    """Issuer activity — mint volume and last active ledger, from indexed events."""
+    events = await _fetch_events("VaccinationMinted")
+    stats: dict[str, dict] = {}
+    for e in events:
+        issuer = e.get("payload", {}).get("issuer") or e.get("payload", {}).get("2")
+        if not issuer:
+            continue
+        issuer = str(issuer)
+        if issuer not in stats:
+            stats[issuer] = {"issuer": issuer, "total_issued": 0, "last_ledger": 0}
+        stats[issuer]["total_issued"] += 1
+        if e.get("ledger", 0) > stats[issuer]["last_ledger"]:
+            stats[issuer]["last_ledger"] = e["ledger"]
+    return {"issuers": list(stats.values())}
 
 
 @router.get("/anomalies")
 async def anomaly_detection():
-    """
-    Flag issuers with unusually high mint volume in a short window.
-    Threshold: >50 mints in 1 hour is flagged.
-    """
-    return {
-        "note": "Anomaly detection based on mint event frequency",
-        "flagged_issuers": [],
-    }
+    """Flag issuers whose total mint count exceeds ANOMALY_THRESHOLD."""
+    events = await _fetch_events("VaccinationMinted")
+    counts: dict[str, int] = defaultdict(int)
+    for e in events:
+        issuer = e.get("payload", {}).get("issuer") or e.get("payload", {}).get("2")
+        if issuer:
+            counts[str(issuer)] += 1
+    flagged = [
+        {"issuer": issuer, "total_issued": count}
+        for issuer, count in counts.items()
+        if count > ANOMALY_THRESHOLD
+    ]
+    return {"flagged_issuers": flagged, "threshold": ANOMALY_THRESHOLD}

--- a/python-service/tests/test_main.py
+++ b/python-service/tests/test_main.py
@@ -1,6 +1,14 @@
 import pytest
+from unittest.mock import patch, AsyncMock
 from httpx import AsyncClient, ASGITransport
 from main import app
+
+
+@pytest.fixture
+def mock_fetch_events():
+    """Patch _fetch_events so analytics tests don't hit a real backend."""
+    with patch("routes.analytics._fetch_events", new_callable=AsyncMock) as m:
+        yield m
 
 
 @pytest.mark.asyncio
@@ -12,11 +20,19 @@ async def test_health():
 
 
 @pytest.mark.asyncio
-async def test_analytics_rates():
+async def test_analytics_rates(mock_fetch_events):
+    mock_fetch_events.return_value = [
+        {"payload": {"vaccine_name": "COVID-19"}, "ledger": 100},
+        {"payload": {"vaccine_name": "COVID-19"}, "ledger": 101},
+        {"payload": {"vaccine_name": "Flu"}, "ledger": 102},
+    ]
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         res = await client.get("/analytics/rates")
     assert res.status_code == 200
-    assert "sample" in res.json()
+    body = res.json()
+    assert body["total_mints"] == 3
+    assert body["rates"]["COVID-19"] == 2
+    assert body["rates"]["Flu"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
 Closes the gap where Soroban contract events were not indexed, leaving the analytics service with no reliable data
  source.
  
  Changes:
  
  - Background poller (indexer/poller.js) fetches contract events from Soroban RPC on a configurable interval
  (EVENT_POLL_INTERVAL_MS, default 15s), starting from the last indexed ledger
  - SQLite store (indexer/db.js) persists events with deduplication via INSERT OR IGNORE on the event ID
  - Indexes VaccinationMinted, IssuerAdded, and IssuerRevoked events
  - GET /events endpoint exposes indexed events with event_type, limit, and offset filters
  - Analytics service (/rates, /issuers, /anomalies) now reads from the indexed store instead of live RPC
  - Added pytest.ini with pythonpath config and fixed test_analytics_rates to mock the backend HTTP call
  
  Tested:
  
  - 29 backend tests passing (indexer dedup, filtering, route, parse logic)
  - 3 Python tests passing (health, analytics rates with mock, batch limit)

closes #38 