### PR TITLE
feat(frontend): add URL-based wallet lookup to VerifyPage

### DIFF
--- a/frontend/src/pages/VerifyPage.jsx
+++ b/frontend/src/pages/VerifyPage.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import VerificationBadge from '../components/VerificationBadge';
 import NFTCard from '../components/NFTCard';
 
@@ -14,13 +14,12 @@ export default function VerifyPage() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const handleVerify = async (e) => {
-    e.preventDefault();
+  const verify = async (address) => {
     setLoading(true);
     setError(null);
     setResult(null);
     try {
-      const res = await fetch(`/verify/${wallet.trim()}`);
+      const res = await fetch(`/verify/${address.trim()}`);
       const data = await res.json();
       if (!res.ok) throw new Error(data.error);
       setResult(data);
@@ -29,6 +28,24 @@ export default function VerifyPage() {
     } finally {
       setLoading(false);
     }
+  };
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const w = params.get('wallet');
+    if (w) {
+      setWallet(w);
+      verify(w);
+    }
+  }, []);
+
+  const handleVerify = (e) => {
+    e.preventDefault();
+    const trimmed = wallet.trim();
+    const url = new URL(window.location);
+    url.searchParams.set('wallet', trimmed);
+    window.history.pushState({}, '', url);
+    verify(trimmed);
   };
 
   return (


### PR DESCRIPTION
## Summary

Resolves #14

## Changes

- Read `?wallet=` query param on mount and auto-trigger verification
- Update URL with `pushState` when user manually submits a wallet address
- Shareable links like `/verify?wallet=G...` now work correctly

## Acceptance Criteria

- [x] VerifyPage reads wallet address from URL query param `?wallet=G...`
- [x] If param present, verification runs automatically on page load
- [x] URL updates when user manually enters a wallet address
- [x] Shareable links work correctly