### PR TITLE
Add string input validation with 100 character limit at contract boundary

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -1,0 +1,25 @@
+# VacciChain Contract
+
+## String input validation
+
+The contract validates string inputs at the contract boundary before any storage operations.
+
+### Limits
+
+- `vaccine_name`: maximum 100 characters
+- `date_administered`: maximum 100 characters
+- `name` (issuer metadata): maximum 100 characters
+- `license` (issuer metadata): maximum 100 characters
+- `country` (issuer metadata): maximum 100 characters
+
+### Errors
+
+When a string input exceeds the configured limit, the contract returns an invalid input error variant:
+
+- `InvalidInputVaccineName`
+- `InvalidInputDateAdministered`
+- `InvalidInputIssuerName`
+- `InvalidInputLicense`
+- `InvalidInputCountry`
+
+This prevents excessively long strings from being stored on ledger state and keeps ledger fees bounded.

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -17,8 +17,15 @@ use storage::{DataKey, IssuerRecord, VaccinationRecord};
 /// | 3    | Unauthorized     | Caller is not an authorized issuer               |
 /// | 4    | ProposalExpired  | Admin transfer proposal has expired              |
 /// | 5    | NoPendingTransfer | No pending admin transfer exists                |
-/// | 6    | DuplicateRecord  | Identical vaccination record already exists      |
-/// | 7    | SoulboundToken   | Tokens are non-transferable (soulbound)          |
+/// | 6    | DuplicateRecord              | Identical vaccination record already exists      |
+/// | 7    | RecordNotFound               | Vaccination record does not exist                |
+/// | 8    | AlreadyRevoked               | Vaccination record is already revoked           |
+/// | 9    | InvalidInput                 | Input failed validation at the contract boundary |
+/// | 10   | InvalidInputVaccineName      | vaccine_name exceeds maximum length             |
+/// | 11   | InvalidInputDateAdministered | date_administered exceeds maximum length        |
+/// | 12   | InvalidInputIssuerName       | issuer name exceeds maximum length              |
+/// | 13   | InvalidInputLicense          | issuer license exceeds maximum length           |
+/// | 14   | InvalidInputCountry          | issuer country exceeds maximum length           |
 #[contracterror]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum ContractError {
@@ -30,6 +37,28 @@ pub enum ContractError {
     DuplicateRecord = 6,
     RecordNotFound = 7,
     AlreadyRevoked = 8,
+    InvalidInput = 9,
+    InvalidInputVaccineName = 10,
+    InvalidInputDateAdministered = 11,
+    InvalidInputIssuerName = 12,
+    InvalidInputLicense = 13,
+    InvalidInputCountry = 14,
+}
+
+const MAX_STRING_LENGTH: u32 = 100;
+
+fn validate_input_length(field: &String, field_name: &str) -> Result<(), ContractError> {
+    if field.len() > MAX_STRING_LENGTH {
+        return Err(match field_name {
+            "vaccine_name" => ContractError::InvalidInputVaccineName,
+            "date_administered" => ContractError::InvalidInputDateAdministered,
+            "name" => ContractError::InvalidInputIssuerName,
+            "license" => ContractError::InvalidInputLicense,
+            "country" => ContractError::InvalidInputCountry,
+            _ => ContractError::InvalidInput,
+        });
+    }
+    Ok(())
 }
 
 #[contract]
@@ -49,9 +78,19 @@ impl VacciChainContract {
     }
 
     /// Admin: authorize a new issuer with metadata
-    pub fn add_issuer(env: Env, issuer: Address, name: String, license: String, country: String) {
+    pub fn add_issuer(
+        env: Env,
+        issuer: Address,
+        name: String,
+        license: String,
+        country: String,
+    ) -> Result<(), ContractError> {
         let admin: Address = env.storage().persistent().get(&DataKey::Admin).expect("not initialized");
         admin.require_auth();
+
+        validate_input_length(&name, "name")?;
+        validate_input_length(&license, "license")?;
+        validate_input_length(&country, "country")?;
 
         let record = IssuerRecord {
             name,
@@ -62,6 +101,7 @@ impl VacciChainContract {
 
         env.storage().persistent().set(&DataKey::Issuer(issuer.clone()), &record);
         events::emit_issuer_added(&env, &issuer, &admin);
+        Ok(())
     }
 
     /// Public: get issuer metadata
@@ -215,7 +255,7 @@ mod tests {
             &String::from_str(&env, "General Hospital"),
             &String::from_str(&env, "LIC-12345"),
             &String::from_str(&env, "USA"),
-        );
+        ).unwrap();
 
         let token_id = client.mint_vaccination(
             &patient,
@@ -296,7 +336,7 @@ mod tests {
             &String::from_str(&env, "General Hospital"),
             &String::from_str(&env, "LIC-12345"),
             &String::from_str(&env, "USA"),
-        );
+        ).unwrap();
 
         client.mint_vaccination(
             &patient,
@@ -312,6 +352,60 @@ mod tests {
             &issuer,
         );
         assert_eq!(result, Err(Ok(ContractError::DuplicateRecord)));
+    }
+
+    #[test]
+    fn test_add_issuer_invalid_input_name_too_long() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(VacciChainContract, ());
+        let client = VacciChainContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        client.initialize(&admin).unwrap();
+
+        let long_name = "A".repeat(101);
+        let result = client.try_add_issuer(
+            &issuer,
+            &String::from_str(&env, &long_name),
+            &String::from_str(&env, "LIC-12345"),
+            &String::from_str(&env, "USA"),
+        );
+
+        assert_eq!(result, Err(Ok(ContractError::InvalidInputIssuerName)));
+    }
+
+    #[test]
+    fn test_mint_vaccination_invalid_input_vaccine_name_too_long() {
+        let env = Env::default();
+        env.mock_all_auths();
+
+        let contract_id = env.register(VacciChainContract, ());
+        let client = VacciChainContractClient::new(&env, &contract_id);
+
+        let admin = Address::generate(&env);
+        let issuer = Address::generate(&env);
+        let patient = Address::generate(&env);
+
+        client.initialize(&admin).unwrap();
+        client.add_issuer(
+            &issuer,
+            &String::from_str(&env, "General Hospital"),
+            &String::from_str(&env, "LIC-12345"),
+            &String::from_str(&env, "USA"),
+        ).unwrap();
+
+        let long_vaccine = "A".repeat(101);
+        let result = client.try_mint_vaccination(
+            &patient,
+            &String::from_str(&env, &long_vaccine),
+            &String::from_str(&env, "2024-01-15"),
+            &issuer,
+        );
+
+        assert_eq!(result, Err(Ok(ContractError::InvalidInputVaccineName)));
     }
 
     #[test]
@@ -348,7 +442,7 @@ mod tests {
             &String::from_str(&env, "General Hospital"),
             &String::from_str(&env, "LIC-12345"),
             &String::from_str(&env, "USA"),
-        );
+        ).unwrap();
         client.mint_vaccination(
             &vaccinated_patient,
             &String::from_str(&env, "COVID-19"),
@@ -390,7 +484,7 @@ mod tests {
             &String::from_str(&env, "General Hospital"),
             &String::from_str(&env, "LIC-12345"),
             &String::from_str(&env, "USA"),
-        );
+        ).unwrap();
 
         let mut wallets: Vec<Address> = Vec::new(&env);
         for _ in 0..100u32 {
@@ -450,7 +544,7 @@ mod tests {
             &String::from_str(&env, "General Hospital"),
             &String::from_str(&env, "LIC-12345"),
             &String::from_str(&env, "USA"),
-        );
+        ).unwrap();
         client.mint_vaccination(
             &patient,
             &String::from_str(&env, "Flu"),
@@ -499,7 +593,7 @@ mod tests {
             &String::from_str(&env, "General Hospital"),
             &String::from_str(&env, "LIC-12345"),
             &String::from_str(&env, "USA"),
-        );
+        ).unwrap();
     }
 
     #[test]
@@ -520,7 +614,7 @@ mod tests {
             &String::from_str(&env, "General Hospital"),
             &String::from_str(&env, "LIC-12345"),
             &String::from_str(&env, "USA"),
-        );
+        ).unwrap();
 
         let token_id = client.mint_vaccination(
             &patient,
@@ -561,7 +655,7 @@ mod tests {
             &String::from_str(&env, "General Hospital"),
             &String::from_str(&env, "LIC-12345"),
             &String::from_str(&env, "USA"),
-        );
+        ).unwrap();
 
         let token_id = client.mint_vaccination(
             &patient,
@@ -595,7 +689,7 @@ mod tests {
             &String::from_str(&env, "General Hospital"),
             &String::from_str(&env, "LIC-12345"),
             &String::from_str(&env, "USA"),
-        );
+        ).unwrap();
 
         let token_id = client.mint_vaccination(
             &patient,

--- a/contracts/src/mint.rs
+++ b/contracts/src/mint.rs
@@ -2,6 +2,7 @@ use soroban_sdk::{Env, Address, String, Vec};
 use crate::storage::{DataKey, VaccinationRecord, IssuerRecord};
 use crate::events;
 use crate::ContractError;
+use crate::validate_input_length;
 
 pub fn mint_vaccination(
     env: &Env,
@@ -10,6 +11,9 @@ pub fn mint_vaccination(
     date_administered: String,
     issuer: Address,
 ) -> Result<u64, ContractError> {
+    validate_input_length(&vaccine_name, "vaccine_name")?;
+    validate_input_length(&date_administered, "date_administered")?;
+
     // Require issuer auth
     issuer.require_auth();
 


### PR DESCRIPTION
Closes #49

---

## Description
Adds comprehensive string input validation to prevent excessively long strings from bloating storage and increasing ledger fees.

## Changes
- Add `MAX_STRING_LENGTH = 100` constant to contract
- Implement `validate_input_length()` function validating at contract boundary
- Add `InvalidInput` error variants (codes 9-14) for each field type
- Update `add_issuer()` to return Result with validation
- Update `mint_vaccination()` to validate inputs before storage
- Add contract tests for validation
- Document string limits in contracts README

## Acceptance Criteria Met
- [x] vaccine_name max length: 100 characters
- [x] All string inputs validated at contract boundary before storage
- [x] InvalidInput error returned with field name on violation
- [x] Limits documented in contract README