### PR TITLE
Feat/mint confirmation dialog

### DIFF
--- a/frontend/src/components/ConfirmMintDialog.jsx
+++ b/frontend/src/components/ConfirmMintDialog.jsx
@@ -1,0 +1,39 @@
+const overlay = {
+  position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)',
+  display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 100,
+};
+const box = {
+  background: '#1e293b', border: '1px solid #334155', borderRadius: 12,
+  padding: '1.5rem', maxWidth: 420, width: '90%', color: '#e2e8f0',
+};
+const row = { display: 'flex', justifyContent: 'space-between', margin: '0.4rem 0', fontSize: '0.9rem' };
+const btnRow = { display: 'flex', gap: '0.75rem', marginTop: '1.5rem' };
+const btnConfirm = { flex: 1, padding: '0.7rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 8, fontSize: '1rem', cursor: 'pointer' };
+const btnCancel = { flex: 1, padding: '0.7rem', background: 'transparent', color: '#94a3b8', border: '1px solid #334155', borderRadius: 8, fontSize: '1rem', cursor: 'pointer' };
+
+export default function ConfirmMintDialog({ record, onConfirm, onCancel }) {
+  // Prevent Enter key from triggering confirm
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') e.preventDefault();
+  };
+
+  return (
+    <div style={overlay} role="dialog" aria-modal="true" aria-labelledby="dialog-title" onKeyDown={handleKeyDown}>
+      <div style={box}>
+        <h3 id="dialog-title" style={{ marginBottom: '1rem', color: '#f1f5f9' }}>Confirm Vaccination Mint</h3>
+        <p style={{ color: '#94a3b8', fontSize: '0.85rem', marginBottom: '1rem' }}>
+          This action is irreversible. Please review the record before confirming.
+        </p>
+        <div style={{ background: '#0f172a', borderRadius: 8, padding: '0.75rem 1rem' }}>
+          <div style={row}><span style={{ color: '#64748b' }}>Patient</span><span style={{ wordBreak: 'break-all', maxWidth: '60%', textAlign: 'right' }}>{record.patient_address}</span></div>
+          <div style={row}><span style={{ color: '#64748b' }}>Vaccine</span><span>{record.vaccine_name}</span></div>
+          <div style={row}><span style={{ color: '#64748b' }}>Date</span><span>{record.date_administered}</span></div>
+        </div>
+        <div style={btnRow}>
+          <button style={btnCancel} onClick={onCancel}>Cancel</button>
+          <button style={btnConfirm} onClick={onConfirm} autoFocus>Confirm &amp; Mint</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/IssuerDashboard.jsx
+++ b/frontend/src/pages/IssuerDashboard.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useAuth } from '../hooks/useFreighter';
 import { useVaccination } from '../hooks/useVaccination';
+import ConfirmMintDialog from '../components/ConfirmMintDialog';
 
 const styles = {
   page: { maxWidth: 500, margin: '2rem auto', padding: '0 1rem' },
@@ -26,6 +27,7 @@ export default function IssuerDashboard() {
     }
   });
   const [success, setSuccess] = useState(null);
+  const [confirming, setConfirming] = useState(false);
 
   // Persist form draft on every change
   useEffect(() => {
@@ -45,9 +47,14 @@ export default function IssuerDashboard() {
     return <div style={styles.page}><p style={{ color: '#f87171' }}>Access denied: issuer role required.</p></div>;
   }
 
-  const handleSubmit = async (e) => {
+  const handleSubmit = (e) => {
     e.preventDefault();
     setSuccess(null);
+    setConfirming(true);
+  };
+
+  const handleConfirm = async () => {
+    setConfirming(false);
     const result = await issueVaccination(form);
     if (result) {
       setSuccess(`Vaccination NFT minted! Token ID: ${result.token_id}`);
@@ -58,6 +65,13 @@ export default function IssuerDashboard() {
 
   return (
     <div style={styles.page}>
+      {confirming && (
+        <ConfirmMintDialog
+          record={form}
+          onConfirm={handleConfirm}
+          onCancel={() => setConfirming(false)}
+        />
+      )}
       <h2 style={{ marginBottom: '1.5rem', color: '#e2e8f0' }}>Issue Vaccination NFT</h2>
       <form style={styles.form} onSubmit={handleSubmit}>
         {[


### PR DESCRIPTION
## Summary

Adds a confirmation dialog to the Issuer Dashboard before submitting the vaccination form. Prevents accidental irreversible on-chain mints from misclicks.

## Changes

**`frontend/src/components/ConfirmMintDialog.jsx`** (new)
- Modal overlay displaying a summary of the record to be minted (patient address, vaccine name, date)
- Requires explicit click on "Confirm & Mint" — Enter key is suppressed at the overlay level
- "Cancel" closes the dialog without losing form data

**`frontend/src/pages/IssuerDashboard.jsx`** (modified)
- `handleSubmit` now opens the dialog instead of calling the API directly
- `handleConfirm` performs the actual `issueVaccination` call
- Cancelling preserves form state in both React state and `sessionStorage`

## Acceptance Criteria

| Criteria | Status |
|---|---|
| Confirmation dialog shown before submitting | ✅ |
| Dialog displays summary of record to be minted | ✅ Patient address, vaccine name, date |
| Requires explicit confirmation click (not Enter) | ✅ Enter key blocked on overlay |
| Cancellable without losing form data | ✅ Form state and sessionStorage preserved |

## Testing

1. Connect an issuer wallet and fill in the vaccination form
2. Click "Issue Vaccination NFT" — confirm the dialog appears with correct field values
3. Press Enter — confirm nothing happens
4. Click "Cancel" — confirm the dialog closes and form fields are unchanged
5. Click "Issue Vaccination NFT" again → "Confirm & Mint" — confirm the mint proceeds

closes #17 