### PR TITLE
feat: add post-deploy smoke test to contracts/Makefile

### DIFF
--- a/contracts/Makefile
+++ b/contracts/Makefile
@@ -7,10 +7,24 @@ test:
 
 deploy:
 	@echo "Deploying to Stellar testnet..."
-	soroban contract deploy \
+	$(eval CONTRACT_ID := $(shell soroban contract deploy \
 		--wasm target/wasm32-unknown-unknown/release/vaccichain.wasm \
 		--source $(ADMIN_SECRET_KEY) \
-		--network testnet
+		--network testnet))
+	@echo "CONTRACT_ID=$(CONTRACT_ID)"
+	@echo "Running post-deploy smoke test..."
+	$(eval SMOKE_RESULT := $(shell soroban contract invoke \
+		--id $(CONTRACT_ID) \
+		--source $(ADMIN_SECRET_KEY) \
+		--network testnet \
+		-- verify_vaccination \
+		--wallet $(ADMIN_PUBLIC_KEY) 2>&1))
+	@echo "Smoke test result: $(SMOKE_RESULT)"
+	@echo "$(SMOKE_RESULT)" | grep -qv "error" || (echo "ERROR: Smoke test failed — $(SMOKE_RESULT)" && exit 1)
+	@echo "Smoke test passed. Writing contract ID to ../.env..."
+	@sed -i 's|^VACCINATIONS_CONTRACT_ID=.*|VACCINATIONS_CONTRACT_ID=$(CONTRACT_ID)|' ../.env 2>/dev/null || \
+		echo "VACCINATIONS_CONTRACT_ID=$(CONTRACT_ID)" >> ../.env
+	@echo "Deploy complete. CONTRACT_ID=$(CONTRACT_ID)"
 
 clean:
 	cargo clean


### PR DESCRIPTION
- Capture CONTRACT_ID from soroban deploy output
- Call verify_vaccination with ADMIN_PUBLIC_KEY as smoke test
- Fail loudly (exit 1) if smoke test returns an error
- Write CONTRACT_ID to ../.env automatically on success

Closes #59