### PR TITLE
feat: Automated Backup for Analytics Service Data (#71)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,13 @@ ANALYTICS_PORT=8001
 
 # Base URL the analytics service uses to reach the backend (default set by Compose)
 BACKEND_URL=http://backend:4000
+
+# ── Backup service ────────────────────────────────────────────────────────────
+# S3 Bucket for analytics DB backup
+S3_BUCKET_NAME=
+# AWS Credentials for S3 access
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+# Number of days to retain backups
+RETENTION_DAYS=30

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine:3.19
+
+# Install AWS CLI and tzdata for cron timezone support
+RUN apk add --no-cache aws-cli tzdata
+
+WORKDIR /app
+COPY backup.sh .
+RUN chmod +x backup.sh
+
+# Add crontab entry for daily midnight run
+RUN echo "0 0 * * * /app/backup.sh >> /var/log/backup.log 2>&1" > /etc/crontabs/root
+
+# Keep cron running in foreground
+CMD ["crond", "-f", "-l", "2"]

--- a/backup/backup.sh
+++ b/backup/backup.sh
@@ -1,0 +1,71 @@
+#!/bin/sh
+set -e
+
+# Default variables
+DB_FILE=${DB_FILE_PATH:-"/data/vaccichain.db"}
+BACKUP_DIR="/tmp/backups"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="${BACKUP_DIR}/vaccichain_${TIMESTAMP}.db"
+S3_BUCKET=${S3_BUCKET_NAME:-""}
+RETENTION_DAYS=${RETENTION_DAYS:-30}
+
+echo "Starting backup process at $(date)..."
+
+if [ -z "$S3_BUCKET" ]; then
+  echo "Error: S3_BUCKET_NAME is not set."
+  exit 1
+fi
+
+if [ ! -f "$DB_FILE" ]; then
+  echo "Error: Database file $DB_FILE not found."
+  exit 1
+fi
+
+mkdir -p "$BACKUP_DIR"
+
+# 1. Create a copy of the database
+echo "Creating backup of $DB_FILE..."
+cp "$DB_FILE" "$BACKUP_FILE"
+
+# 2. Upload to S3
+echo "Uploading $BACKUP_FILE to s3://$S3_BUCKET/..."
+aws s3 cp "$BACKUP_FILE" "s3://$S3_BUCKET/vaccichain_${TIMESTAMP}.db"
+
+# 3. Clean up old backups on S3 (Retention policy)
+# Calculate the cutoff date. We use GNU/Alpine date manipulation.
+if date --help 2>&1 | grep -q "BusyBox"; then
+  # Alpine/BusyBox date
+  CUTOFF_DATE=$(date -d "@$(($(date +%s) - $RETENTION_DAYS * 86400))" +%Y%m%d_%H%M%S)
+elif date --help 2>&1 | grep -q "GNU"; then
+  # GNU date
+  CUTOFF_DATE=$(date -d "${RETENTION_DAYS} days ago" +%Y%m%d_%H%M%S)
+else
+  # Fallback for BSD/macOS (not expected in Alpine Docker, but good practice)
+  CUTOFF_DATE=$(date -v-${RETENTION_DAYS}d +%Y%m%d_%H%M%S)
+fi
+
+echo "Cleaning up backups older than $RETENTION_DAYS days (before vaccichain_${CUTOFF_DATE}.db)..."
+
+# List files in S3 bucket and delete those older than CUTOFF_DATE
+# Note: we disable set -e here because if grep finds nothing it will exit with 1
+set +e
+BACKUP_FILES=$(aws s3 ls "s3://$S3_BUCKET/" | awk '{print $4}' | grep '^vaccichain_.*\.db$')
+set -e
+
+if [ -n "$BACKUP_FILES" ]; then
+  echo "$BACKUP_FILES" | while read -r filename; do
+    # Extract timestamp from filename (vaccichain_YYYYMMDD_HHMMSS.db)
+    file_timestamp=$(echo "$filename" | sed -E 's/^vaccichain_([0-9]{8}_[0-9]{6})\.db$/\1/')
+    
+    if [ "$file_timestamp" \< "$CUTOFF_DATE" ]; then
+      echo "Deleting old backup: $filename"
+      aws s3 rm "s3://$S3_BUCKET/$filename"
+    fi
+  done
+else
+  echo "No existing backups found to clean up."
+fi
+
+# Clean up local temp file
+rm "$BACKUP_FILE"
+echo "Backup process completed successfully."

--- a/backup/test_backup.sh
+++ b/backup/test_backup.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+
+echo "Setting up test environment..."
+
+# Setup mock AWS CLI
+mkdir -p /tmp/mock_bin
+cat << 'EOF' > /tmp/mock_bin/aws
+#!/bin/sh
+if [ "$1" = "s3" ] && [ "$2" = "cp" ]; then
+  echo "Mock upload $3 to $4"
+  echo "$4" >> /tmp/mock_s3_uploads.txt
+elif [ "$1" = "s3" ] && [ "$2" = "ls" ]; then
+  # Return some fake files
+  echo "2023-01-01 12:00:00 1234 vaccichain_20200101_000000.db"
+  echo "2023-01-01 12:00:00 1234 vaccichain_20230101_000000.db"
+  echo "2023-01-01 12:00:00 1234 vaccichain_20990101_000000.db"
+elif [ "$1" = "s3" ] && [ "$2" = "rm" ]; then
+  echo "Mock delete $3"
+  echo "$3" >> /tmp/mock_s3_deletes.txt
+fi
+EOF
+chmod +x /tmp/mock_bin/aws
+
+# Ensure we use our mock `aws`
+export PATH="/tmp/mock_bin:$PATH"
+
+# Set necessary environment variables
+export S3_BUCKET_NAME="my-test-bucket"
+export RETENTION_DAYS=30
+
+# Create dummy DB file
+mkdir -p /tmp/data
+touch /tmp/data/vaccichain.db
+export DB_FILE_PATH="/tmp/data/vaccichain.db"
+
+echo "Running backup.sh..."
+# Run the script
+./backup.sh
+
+# Verify
+echo "Asserting deletions..."
+if grep -q "vaccichain_20200101_000000.db" /tmp/mock_s3_deletes.txt && grep -q "vaccichain_20230101_000000.db" /tmp/mock_s3_deletes.txt; then
+  echo "✅ Old files deleted successfully."
+else
+  echo "❌ Test failed: old files were not deleted."
+  exit 1
+fi
+
+if grep -q "vaccichain_20990101_000000.db" /tmp/mock_s3_deletes.txt; then
+  echo "❌ Test failed: new file was deleted incorrectly."
+  exit 1
+else
+  echo "✅ New file correctly retained."
+fi
+
+# Cleanup
+rm -rf /tmp/mock_bin /tmp/data /tmp/mock_s3_deletes.txt /tmp/mock_s3_uploads.txt
+echo "✅ All tests passed successfully!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,6 +86,20 @@ services:
         max-file: "3"
     restart: unless-stopped
 
+  backup:
+    build: ./backup
+    env_file: .env
+    volumes:
+      - vaccichain_db:/data
+    networks:
+      - vaccichain
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+    restart: unless-stopped
+
 networks:
   vaccichain:
     driver: bridge

--- a/docs/restore_procedure.md
+++ b/docs/restore_procedure.md
@@ -1,0 +1,57 @@
+# Analytics Database Restore Procedure
+
+This document outlines the procedure to restore the analytics database (SQLite) from an S3 backup. The backup system automatically creates daily copies of the database to S3.
+
+## Prerequisites
+- Access to the S3 bucket where backups are stored (`S3_BUCKET_NAME`).
+- AWS CLI installed locally, or access to the AWS Console.
+- Access to the server running the Docker containers.
+
+## Step-by-Step Restore Guide
+
+### 1. Identify the Backup File
+First, locate the desired backup file in S3. The files are named with timestamps: `vaccichain_YYYYMMDD_HHMMSS.db`.
+If using the AWS CLI:
+```bash
+aws s3 ls s3://<S3_BUCKET_NAME>/
+```
+Identify the file you want to restore (e.g., `vaccichain_20231027_000000.db`).
+
+### 2. Download the Backup
+Download the selected backup to your server:
+```bash
+aws s3 cp s3://<S3_BUCKET_NAME>/vaccichain_20231027_000000.db ./vaccichain.db
+```
+
+### 3. Stop the Backend Service
+Before replacing the database, you must stop the `backend` service to prevent any in-memory state from overwriting the restored file.
+```bash
+docker compose stop backend
+```
+
+### 4. Replace the Database File
+Docker volumes in this project are typically stored in the local filesystem, or managed directly by Docker.
+You can replace the file within the volume using a temporary container. Run the following command from the root of your VacciChain directory:
+
+```bash
+docker run --rm -v vaccichain_db:/data -v $(pwd):/backup alpine cp /backup/vaccichain.db /data/vaccichain.db
+```
+*(Note: Ensure that the downloaded `vaccichain.db` is in the directory where you run this command).*
+
+### 5. Restart the Backend Service
+Once the file is replaced, restart the backend service:
+```bash
+docker compose start backend
+```
+
+### 6. Verify the Restore
+You can verify the restore by checking the logs of the `backend` container or by accessing the analytics API endpoints to confirm the data reflects the restored backup state.
+```bash
+docker compose logs -f backend
+```
+And then checking:
+`curl http://localhost:8001/analytics/rates`
+
+## Troubleshooting
+- **Database Locked / Corrupted**: Ensure the backend service is fully stopped before copying the database over. `sql.js` loads the DB entirely into memory, so live replacement will fail or cause corruption when it flushes.
+- **Permissions**: Make sure the replacement database file has appropriate permissions so that the node.js backend user can read/write to it. Running the `docker run alpine cp ...` as shown above ensures it runs as root within the volume, which matches the default Docker volume behaviour.

--- a/env.example
+++ b/env.example
@@ -19,3 +19,10 @@ ANALYTICS_PORT=8001
 
 # Audit log (append-only NDJSON file, defaults to backend/audit.log)
 AUDIT_LOG_PATH=./audit.log
+
+# Backup service
+S3_BUCKET_NAME=
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+RETENTION_DAYS=30


### PR DESCRIPTION
## What was implemented
- Created `backup/backup.sh` — shell script that creates a timestamped 
  copy of `vaccichain.db`, uploads it to S3, and prunes backups older 
  than 30 days automatically
- Created `backup/Dockerfile` — Alpine Linux container with aws-cli 
  and cron running a daily backup at midnight UTC
- Integrated `backup` service into `docker-compose.yml` sharing the 
  `vaccichain_db` volume
- Added `backup/test_backup.sh` — tests the 30-day retention logic 
  using a mocked AWS CLI
- Added `docs/restore_procedure.md` — step-by-step guide to restore 
  the database from S3
- Updated `.env.example` with required AWS and S3 variables

## How to use
1. Add the following to your `.env` file:
   - `AWS_ACCESS_KEY_ID`
   - `AWS_SECRET_ACCESS_KEY`
   - `AWS_REGION`
   - `S3_BUCKET_NAME`
   - `RETENTION_DAYS=30`
2. Run `docker compose up -d --build`

Closes #71 