### PR TITLE
feat: limit JSON body size to 10kb (configurable via BODY_LIMIT)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,9 @@ JWT_SECRET=
 # TCP port for the Express backend (default: 4000)
 PORT=4000
 
+# Maximum JSON request body size accepted by the API (default: 10kb)
+BODY_LIMIT=10kb
+
 # ── Rate limiting ─────────────────────────────────────────────────────────────
 # Max SEP-10 challenge requests per IP per minute (default: 10)
 RATE_LIMIT_SEP10=10

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -14,7 +14,7 @@ const adminRoutes = require('./routes/admin');
 const app = express();
 
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: config.BODY_LIMIT }));
 
 // Request logging middleware
 app.use((req, _res, next) => {

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -21,6 +21,9 @@ const schema = z.object({
   SOROBAN_FEE: z.coerce.number().int().positive().default(100),
   SOROBAN_TIP: z.coerce.number().int().min(0).default(0),
 
+  // Request limits
+  BODY_LIMIT: z.string().default('10kb'),
+
   // Indexer
   EVENT_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(15000),
   DATABASE_PATH: z.string().default('/data/vaccichain.db'),

--- a/backend/tests/body-limit.test.js
+++ b/backend/tests/body-limit.test.js
@@ -1,0 +1,16 @@
+const request = require('supertest');
+const app = require('../src/app');
+
+describe('Body size limit', () => {
+  it('returns 413 when JSON body exceeds limit', async () => {
+    const large = { data: 'x'.repeat(11 * 1024) }; // > 10 kb
+    const res = await request(app).post('/auth/sep10').send(large);
+    expect(res.status).toBe(413);
+  });
+
+  it('accepts requests within the limit', async () => {
+    const small = { public_key: 'GABC' };
+    const res = await request(app).post('/auth/sep10').send(small);
+    expect(res.status).not.toBe(413);
+  });
+});


### PR DESCRIPTION
 feat: limit JSON body size to 10kb (configurable via BODY_LIMIT)
  
  Summary
  
  Adds a request body size limit to the Express app to prevent large payloads
  from exhausting server memory.
  
  Changes
  
  - express.json() now enforces a configurable size limit (default: 10kb)
  - BODY_LIMIT env var added to config schema with Zod validation
  - Requests exceeding the limit automatically receive 413 Payload Too Large
  - .env.example updated with BODY_LIMIT=10kb
  
  Testing
  
  - Added tests/body-limit.test.js with two cases: oversized payload returns 413,
  normal payload passes through
  - Both tests pass
  
  Configuration
  
  Set BODY_LIMIT in .env to override the default (e.g. BODY_LIMIT=50kb). Accepts
  any value supported by the bytes (https://www.npmjs.com/package/bytes) library
  (kb, mb, etc.).
  closes #28
