### PR TITLE
feat: verifier API key system for third-party vaccination checks

### DIFF
--- a/backend/src/indexer/db.js
+++ b/backend/src/indexer/db.js
@@ -20,6 +20,14 @@ const SCHEMA = `
   );
   CREATE INDEX IF NOT EXISTS idx_events_type ON events(event_type);
   CREATE INDEX IF NOT EXISTS idx_events_ledger ON events(ledger);
+
+  CREATE TABLE IF NOT EXISTS api_keys (
+    id          TEXT PRIMARY KEY,
+    key_hash    TEXT NOT NULL UNIQUE,
+    label       TEXT NOT NULL,
+    created_at  TEXT NOT NULL,
+    revoked     INTEGER NOT NULL DEFAULT 0
+  );
 `;
 
 /** Persist in-memory DB to disk. */
@@ -96,4 +104,39 @@ function getLatestLedger() {
   return res[0].values[0][0];
 }
 
-module.exports = { initDb, upsertEvents, queryEvents, getLatestLedger };
+// ── API key CRUD ──────────────────────────────────────────────────────────────
+
+function insertApiKey({ id, key_hash, label, created_at }) {
+  db.run(
+    'INSERT INTO api_keys (id, key_hash, label, created_at, revoked) VALUES (?,?,?,?,0)',
+    [id, key_hash, label, created_at]
+  );
+  flush();
+}
+
+function getApiKeyByHash(key_hash) {
+  const res = db.exec('SELECT * FROM api_keys WHERE key_hash = ?', [key_hash]);
+  if (!res.length) return null;
+  const { columns, values } = res[0];
+  const obj = {};
+  columns.forEach((col, i) => { obj[col] = values[0][i]; });
+  return obj;
+}
+
+function listApiKeys() {
+  const res = db.exec('SELECT id, label, created_at, revoked FROM api_keys ORDER BY created_at DESC');
+  if (!res.length) return [];
+  const { columns, values } = res[0];
+  return values.map(row => {
+    const obj = {};
+    columns.forEach((col, i) => { obj[col] = row[i]; });
+    return obj;
+  });
+}
+
+function revokeApiKey(id) {
+  db.run('UPDATE api_keys SET revoked = 1 WHERE id = ?', [id]);
+  flush();
+}
+
+module.exports = { initDb, upsertEvents, queryEvents, getLatestLedger, insertApiKey, getApiKeyByHash, listApiKeys, revokeApiKey };

--- a/backend/src/middleware/rateLimiter.js
+++ b/backend/src/middleware/rateLimiter.js
@@ -1,16 +1,19 @@
 const rateLimit = require('express-rate-limit');
 
-const make = (maxEnvVar, defaultMax) =>
+const make = (maxEnvVar, defaultMax, keyGen) =>
   rateLimit({
     windowMs: 60 * 1000,
     max: parseInt(process.env[maxEnvVar] ?? defaultMax, 10),
-    standardHeaders: true,  // sends Retry-After
+    standardHeaders: true,
     legacyHeaders: false,
+    keyGenerator: keyGen,
     handler: (_req, res, _next, options) =>
       res.status(429).json({ error: 'Too many requests', retryAfter: options.windowMs / 1000 }),
   });
 
 module.exports = {
-  verifyLimiter: make('RATE_LIMIT_VERIFY', 60),
-  sep10Limiter:  make('RATE_LIMIT_SEP10', 10),
+  verifyLimiter:    make('RATE_LIMIT_VERIFY', 60),
+  sep10Limiter:     make('RATE_LIMIT_SEP10', 10),
+  // Keyed by verifier API key id so each third-party has its own bucket
+  verifierKeyLimiter: make('RATE_LIMIT_VERIFIER_KEY', 120, (req) => req.verifier?.id ?? req.ip),
 };

--- a/backend/src/middleware/verifierApiKey.js
+++ b/backend/src/middleware/verifierApiKey.js
@@ -1,0 +1,24 @@
+const crypto = require('crypto');
+const { getApiKeyByHash } = require('../indexer/db');
+
+/**
+ * Middleware: validate X-API-Key header against the api_keys table.
+ * On success, attaches req.verifier = { id, label } and calls next().
+ * On failure, returns 401.
+ */
+function verifierApiKey(req, res, next) {
+  const raw = req.headers['x-api-key'];
+  if (!raw) return res.status(401).json({ error: 'Missing X-API-Key header' });
+
+  const hash = crypto.createHash('sha256').update(raw).digest('hex');
+  const record = getApiKeyByHash(hash);
+
+  if (!record || record.revoked) {
+    return res.status(401).json({ error: 'Invalid or revoked API key' });
+  }
+
+  req.verifier = { id: record.id, label: record.label };
+  next();
+}
+
+module.exports = verifierApiKey;

--- a/backend/src/routes/admin.js
+++ b/backend/src/routes/admin.js
@@ -1,13 +1,11 @@
 const express = require('express');
+const crypto = require('crypto');
 const authMiddleware = require('../middleware/auth');
 const { queryAuditLog } = require('../middleware/auditLog');
+const { insertApiKey, listApiKeys, revokeApiKey } = require('../indexer/db');
 
 const router = express.Router();
 
-/**
- * Require admin (issuer) role.
- * Reuses the same role that guards vaccination issuance.
- */
 function adminOnly(req, res, next) {
   if (req.user?.role !== 'issuer') {
     return res.status(403).json({ error: 'Admin access required' });
@@ -17,19 +15,12 @@ function adminOnly(req, res, next) {
 
 /**
  * GET /admin/audit
- * Query params:
- *   actor  — filter by Stellar public key
- *   from   — ISO date string (inclusive lower bound)
- *   to     — ISO date string (inclusive upper bound)
- *   limit  — max entries to return (default 100, max 1000)
- *   offset — pagination offset (default 0)
  */
 router.get('/audit', authMiddleware, adminOnly, (req, res) => {
   const { actor, from, to } = req.query;
   const limit  = Math.min(parseInt(req.query.limit  || '100', 10), 1000);
   const offset = Math.max(parseInt(req.query.offset || '0',   10), 0);
 
-  // Basic date validation
   if (from && isNaN(new Date(from).getTime())) {
     return res.status(400).json({ error: 'Invalid "from" date' });
   }
@@ -39,8 +30,46 @@ router.get('/audit', authMiddleware, adminOnly, (req, res) => {
 
   const entries = queryAuditLog({ actor, from, to });
   const page    = entries.slice(offset, offset + limit);
-
   res.json({ total: entries.length, offset, limit, entries: page });
+});
+
+// ── API key management ────────────────────────────────────────────────────────
+
+/**
+ * POST /admin/api-keys
+ * Body: { label: string }
+ * Returns the raw key once — it is never stored in plaintext.
+ */
+router.post('/api-keys', authMiddleware, adminOnly, (req, res) => {
+  const { label } = req.body;
+  if (!label || typeof label !== 'string' || !label.trim()) {
+    return res.status(400).json({ error: 'label is required' });
+  }
+
+  const rawKey  = crypto.randomBytes(32).toString('hex');
+  const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex');
+  const id      = crypto.randomUUID();
+
+  insertApiKey({ id, key_hash: keyHash, label: label.trim(), created_at: new Date().toISOString() });
+
+  res.status(201).json({ id, label: label.trim(), key: rawKey });
+});
+
+/**
+ * GET /admin/api-keys
+ * Returns all keys (without the raw key value).
+ */
+router.get('/api-keys', authMiddleware, adminOnly, (_req, res) => {
+  res.json(listApiKeys());
+});
+
+/**
+ * DELETE /admin/api-keys/:id
+ * Revokes a key by id.
+ */
+router.delete('/api-keys/:id', authMiddleware, adminOnly, (req, res) => {
+  revokeApiKey(req.params.id);
+  res.json({ revoked: true });
 });
 
 module.exports = router;

--- a/backend/src/routes/verify.js
+++ b/backend/src/routes/verify.js
@@ -2,23 +2,62 @@ const express = require('express');
 const StellarSdk = require('@stellar/stellar-sdk');
 const { validateStellarPublicKey } = require('../middleware/wallet');
 const { simulateContract } = require('../stellar/soroban');
-const { verifyLimiter } = require('../middleware/rateLimiter');
+const { verifyLimiter, verifierKeyLimiter } = require('../middleware/rateLimiter');
+const verifierApiKey = require('../middleware/verifierApiKey');
+const authMiddleware = require('../middleware/auth');
+const { audit } = require('../middleware/auditLog');
 
 const router = express.Router();
 
-// GET /verify/:wallet — public, no auth required
-router.get('/:wallet', validateStellarPublicKey('params', 'wallet', 'wallet'), async (req, res) => {
-  const { wallet } = req.params;
-
-  try {
-    const args = [StellarSdk.Address.fromString(wallet).toScVal()];
-    const result = await simulateContract('verify_vaccination', args);
-    const [vaccinated, records] = StellarSdk.scValToNative(result);
-
-    res.json({ wallet, vaccinated, record_count: records.length, records });
-  } catch (err) {
-    res.status(500).json({ error: err.message });
+/**
+ * Try JWT first; if no Authorization header, fall through to API key auth.
+ * One of the two must succeed — otherwise 401.
+ */
+function jwtOrApiKey(req, res, next) {
+  if (req.headers.authorization) {
+    return authMiddleware(req, res, next);
   }
-});
+  return verifierApiKey(req, res, next);
+}
+
+/**
+ * Pick the right rate limiter based on how the caller authenticated.
+ * API-key callers get verifierKeyLimiter; JWT callers get verifyLimiter.
+ */
+function adaptiveLimiter(req, res, next) {
+  if (req.verifier) return verifierKeyLimiter(req, res, next);
+  return verifyLimiter(req, res, next);
+}
+
+// GET /verify/:wallet — JWT or verifier API key
+router.get(
+  '/:wallet',
+  validateStellarPublicKey('params', 'wallet', 'wallet'),
+  jwtOrApiKey,
+  adaptiveLimiter,
+  async (req, res) => {
+    const { wallet } = req.params;
+    const actor = req.verifier ? `apikey:${req.verifier.id}` : (req.user?.wallet ?? 'unknown');
+
+    try {
+      const args = [StellarSdk.Address.fromString(wallet).toScVal()];
+      const result = await simulateContract('verify_vaccination', args);
+      const [vaccinated, records] = StellarSdk.scValToNative(result);
+
+      audit({
+        actor,
+        action: 'verify.lookup',
+        target: wallet,
+        result: 'success',
+        meta: req.verifier ? { verifier_label: req.verifier.label } : {},
+      });
+
+      res.json({ wallet, vaccinated, record_count: records.length, records });
+    } catch (err) {
+      audit({ actor, action: 'verify.lookup', target: wallet, result: 'failure', meta: { error: err.message } });
+      res.status(500).json({ error: err.message });
+    }
+  }
+);
 
 module.exports = router;

--- a/backend/tests/verifier-api-key.test.js
+++ b/backend/tests/verifier-api-key.test.js
@@ -1,0 +1,165 @@
+const os      = require('os');
+const path    = require('path');
+const fs      = require('fs');
+const request = require('supertest');
+const crypto  = require('crypto');
+const jwt     = require('jsonwebtoken');
+const { initDb, insertApiKey, revokeApiKey } = require('../src/indexer/db');
+const app     = require('../src/app');
+
+const tmpDb = path.join(os.tmpdir(), `vaccichain-apikey-test-${Date.now()}.db`);
+
+beforeAll(async () => {
+  await initDb(tmpDb);
+});
+
+afterAll(() => {
+  if (fs.existsSync(tmpDb)) fs.unlinkSync(tmpDb);
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const VALID_WALLET = 'GAAZI4TCR3TY5OJHCTJC2A4QSY6CJWJH5IAJTGKIN2ER7LBNVKOCCWN';
+
+function issuerToken() {
+  return jwt.sign(
+    { sub: 'admin', role: 'issuer', wallet: VALID_WALLET, exp: Math.floor(Date.now() / 1000) + 3600 },
+    process.env.JWT_SECRET
+  );
+}
+
+// ── admin API key routes ──────────────────────────────────────────────────────
+
+describe('POST /admin/api-keys', () => {
+  it('requires auth', async () => {
+    const res = await request(app).post('/admin/api-keys').send({ label: 'Test' });
+    expect(res.status).toBe(401);
+  });
+
+  it('requires issuer role', async () => {
+    const token = jwt.sign(
+      { sub: 'p', role: 'patient', wallet: VALID_WALLET, exp: Math.floor(Date.now() / 1000) + 3600 },
+      process.env.JWT_SECRET
+    );
+    const res = await request(app)
+      .post('/admin/api-keys')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ label: 'Test' });
+    expect(res.status).toBe(403);
+  });
+
+  it('rejects missing label', async () => {
+    const res = await request(app)
+      .post('/admin/api-keys')
+      .set('Authorization', `Bearer ${issuerToken()}`)
+      .send({});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/label/);
+  });
+
+  it('creates a key and returns it once', async () => {
+    const res = await request(app)
+      .post('/admin/api-keys')
+      .set('Authorization', `Bearer ${issuerToken()}`)
+      .send({ label: 'School A' });
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ label: 'School A' });
+    expect(typeof res.body.key).toBe('string');
+    expect(res.body.key).toHaveLength(64); // 32 bytes hex
+    expect(typeof res.body.id).toBe('string');
+  });
+});
+
+describe('GET /admin/api-keys', () => {
+  it('requires auth', async () => {
+    const res = await request(app).get('/admin/api-keys');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns list of keys without raw key value', async () => {
+    const res = await request(app)
+      .get('/admin/api-keys')
+      .set('Authorization', `Bearer ${issuerToken()}`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+    // raw key must never appear in list
+    res.body.forEach(k => expect(k.key).toBeUndefined());
+    res.body.forEach(k => expect(k.key_hash).toBeUndefined());
+  });
+});
+
+describe('DELETE /admin/api-keys/:id', () => {
+  it('revokes a key', async () => {
+    const createRes = await request(app)
+      .post('/admin/api-keys')
+      .set('Authorization', `Bearer ${issuerToken()}`)
+      .send({ label: 'To Revoke' });
+    expect(createRes.status).toBe(201);
+    const { id } = createRes.body;
+
+    const revokeRes = await request(app)
+      .delete(`/admin/api-keys/${id}`)
+      .set('Authorization', `Bearer ${issuerToken()}`);
+    expect(revokeRes.status).toBe(200);
+    expect(revokeRes.body.revoked).toBe(true);
+
+    // Key should now appear as revoked in list
+    const listRes = await request(app)
+      .get('/admin/api-keys')
+      .set('Authorization', `Bearer ${issuerToken()}`);
+    const found = listRes.body.find(k => k.id === id);
+    expect(found.revoked).toBeTruthy();
+  });
+});
+
+// ── verifierApiKey middleware ─────────────────────────────────────────────────
+
+describe('verifierApiKey middleware', () => {
+  const verifierApiKey = require('../src/middleware/verifierApiKey');
+
+  function makeReqRes(headerValue) {
+    const req = { headers: headerValue !== undefined ? { 'x-api-key': headerValue } : {} };
+    const res = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    const next = jest.fn();
+    return { req, res, next };
+  }
+
+  it('rejects missing header', () => {
+    const { req, res, next } = makeReqRes(undefined);
+    verifierApiKey(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects unknown key', () => {
+    const { req, res, next } = makeReqRes('unknownkey');
+    verifierApiKey(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('accepts a valid active key', () => {
+    const rawKey  = crypto.randomBytes(32).toString('hex');
+    const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex');
+    const id      = crypto.randomUUID();
+    insertApiKey({ id, key_hash: keyHash, label: 'Test', created_at: new Date().toISOString() });
+
+    const { req, res, next } = makeReqRes(rawKey);
+    verifierApiKey(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(req.verifier).toMatchObject({ id, label: 'Test' });
+  });
+
+  it('rejects a revoked key', () => {
+    const rawKey  = crypto.randomBytes(32).toString('hex');
+    const keyHash = crypto.createHash('sha256').update(rawKey).digest('hex');
+    const id      = crypto.randomUUID();
+    insertApiKey({ id, key_hash: keyHash, label: 'Revoked', created_at: new Date().toISOString() });
+    revokeApiKey(id);
+
+    const { req, res, next } = makeReqRes(rawKey);
+    verifierApiKey(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import Landing from './pages/Landing';
 import PatientDashboard from './pages/PatientDashboard';
 import IssuerDashboard from './pages/IssuerDashboard';
 import VerifyPage from './pages/VerifyPage';
+import AdminDashboard from './pages/AdminDashboard';
 import { AuthProvider } from './hooks/useFreighter';
 import FreighterBanner from './components/FreighterBanner';
 
@@ -27,6 +28,7 @@ export default function App() {
         <NavLink to="/patient">My Records</NavLink>
         <NavLink to="/issuer">Issue</NavLink>
         <NavLink to="/verify">Verify</NavLink>
+        <NavLink to="/admin">Admin</NavLink>
       </nav>
       <FreighterBanner />
       <Routes>
@@ -34,6 +36,7 @@ export default function App() {
         <Route path="/patient" element={<PatientDashboard />} />
         <Route path="/issuer" element={<IssuerDashboard />} />
         <Route path="/verify" element={<VerifyPage />} />
+        <Route path="/admin" element={<AdminDashboard />} />
       </Routes>
     </AuthProvider>
   );

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -1,0 +1,137 @@
+import { useState, useEffect, useCallback } from 'react';
+import { useAuth } from '../hooks/useFreighter';
+
+const s = {
+  page:    { maxWidth: 700, width: '100%', margin: '2rem auto', padding: '0 1rem', boxSizing: 'border-box' },
+  table:   { width: '100%', borderCollapse: 'collapse', fontSize: '0.9rem' },
+  th:      { textAlign: 'left', padding: '0.5rem 0.75rem', borderBottom: '1px solid #334155', color: '#94a3b8' },
+  td:      { padding: '0.5rem 0.75rem', borderBottom: '1px solid #1e293b', color: '#e2e8f0', wordBreak: 'break-all' },
+  btn:     { padding: '0.45rem 1rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: '0.9rem' },
+  btnDanger: { padding: '0.45rem 0.75rem', background: '#ef4444', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: '0.85rem' },
+  input:   { padding: '0.5rem 0.75rem', background: '#1e293b', border: '1px solid #334155', borderRadius: 6, color: '#e2e8f0', fontSize: '0.9rem', flex: 1 },
+  row:     { display: 'flex', gap: '0.75rem', marginBottom: '1.5rem', alignItems: 'center' },
+  keyBox:  { marginTop: '1rem', padding: '0.75rem 1rem', background: '#0f172a', borderRadius: 8, color: '#4ade80', fontSize: '0.85rem', wordBreak: 'break-all' },
+  badge:   (revoked) => ({ display: 'inline-block', padding: '0.15rem 0.5rem', borderRadius: 4, fontSize: '0.75rem', background: revoked ? '#7f1d1d' : '#14532d', color: revoked ? '#fca5a5' : '#86efac' }),
+};
+
+export default function AdminDashboard() {
+  const { publicKey, role, connect, apiFetch } = useAuth();
+  const [keys, setKeys]       = useState([]);
+  const [label, setLabel]     = useState('');
+  const [newKey, setNewKey]   = useState(null);
+  const [error, setError]     = useState(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchKeys = useCallback(async () => {
+    const res = await apiFetch('/admin/api-keys');
+    if (res.ok) setKeys(await res.json());
+  }, [apiFetch]);
+
+  useEffect(() => {
+    if (publicKey && role === 'issuer') fetchKeys();
+  }, [publicKey, role, fetchKeys]);
+
+  if (!publicKey) {
+    return (
+      <div style={s.page}>
+        <p style={{ color: '#94a3b8', marginBottom: '1rem' }}>Connect your admin wallet to manage API keys.</p>
+        <button style={s.btn} onClick={connect}>Connect Wallet</button>
+      </div>
+    );
+  }
+
+  if (role !== 'issuer') {
+    return <div style={s.page}><p style={{ color: '#f87171' }}>Access denied: admin role required.</p></div>;
+  }
+
+  const handleCreate = async (e) => {
+    e.preventDefault();
+    if (!label.trim()) return;
+    setLoading(true);
+    setError(null);
+    setNewKey(null);
+    try {
+      const res = await apiFetch('/admin/api-keys', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ label: label.trim() }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error);
+      setNewKey(data.key);
+      setLabel('');
+      await fetchKeys();
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleRevoke = async (id) => {
+    if (!window.confirm('Revoke this API key? This cannot be undone.')) return;
+    await apiFetch(`/admin/api-keys/${id}`, { method: 'DELETE' });
+    await fetchKeys();
+  };
+
+  return (
+    <div style={s.page}>
+      <h2 style={{ marginBottom: '1.5rem', color: 'var(--text)' }}>API Key Management</h2>
+
+      <form style={s.row} onSubmit={handleCreate}>
+        <input
+          style={s.input}
+          placeholder="Label (e.g. School District A)"
+          value={label}
+          onChange={(e) => setLabel(e.target.value)}
+          aria-label="API key label"
+          required
+        />
+        <button style={s.btn} type="submit" disabled={loading} aria-disabled={loading}>
+          {loading ? 'Creating…' : 'Create Key'}
+        </button>
+      </form>
+
+      {error && <p style={{ color: '#f87171', marginBottom: '1rem' }}>{error}</p>}
+
+      {newKey && (
+        <div style={s.keyBox} role="alert">
+          <strong>New API key (copy now — shown once):</strong>
+          <br />
+          <code>{newKey}</code>
+        </div>
+      )}
+
+      {keys.length === 0 ? (
+        <p style={{ color: '#64748b' }}>No API keys yet.</p>
+      ) : (
+        <table style={s.table} aria-label="API keys">
+          <thead>
+            <tr>
+              <th style={s.th}>Label</th>
+              <th style={s.th}>Created</th>
+              <th style={s.th}>Status</th>
+              <th style={s.th}></th>
+            </tr>
+          </thead>
+          <tbody>
+            {keys.map((k) => (
+              <tr key={k.id}>
+                <td style={s.td}>{k.label}</td>
+                <td style={s.td}>{new Date(k.created_at).toLocaleDateString()}</td>
+                <td style={s.td}><span style={s.badge(k.revoked)}>{k.revoked ? 'Revoked' : 'Active'}</span></td>
+                <td style={s.td}>
+                  {!k.revoked && (
+                    <button style={s.btnDanger} onClick={() => handleRevoke(k.id)} aria-label={`Revoke ${k.label}`}>
+                      Revoke
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
feat: verifier API key system for third-party vaccination checks
  
  Closes: Verifier API Key feature (Medium priority)
  
  What
  
  Schools, employers, and border agencies can now verify vaccination status using
  an API key — no Stellar wallet or SEP-10 auth required.
  
  Changes
  
  Backend
  
  - db.js — api_keys table (id, key_hash, label, created_at, revoked) with CRUD
  helpers
  - verifierApiKey.js (new) — middleware that validates X-API-Key header via
  SHA-256 hash lookup; rejects missing/revoked keys
  - rateLimiter.js — verifierKeyLimiter keyed per API key ID (default 120
  req/min, configurable via RATE_LIMIT_VERIFIER_KEY)
  - verify.js — GET /verify/:wallet now accepts either Authorization: Bearer
  <jwt> or X-API-Key: <key>; wallet validation runs before auth so bad addresses
  always return 400; every lookup is audit-logged with actor = apikey:{id}
  - admin.js — three new issuer-only endpoints:
    - POST /admin/api-keys — generate a key, raw value returned once (never
  stored in plaintext)
    - GET /admin/api-keys — list all keys (no hashes or raw values exposed)
    - DELETE /admin/api-keys/:id — revoke a key
  
  Frontend
  
  - AdminDashboard.jsx (new) — create, list, and revoke API keys; raw key shown
  once on creation with copy-now warning
  - App.jsx — /admin route and nav link wired in
  
  Tests
  
  - 11 new tests: admin route auth/role/validation, create/list/revoke flow,
  middleware accept/reject cases
  
  Security notes
  
  - Raw keys are never persisted — only their SHA-256 hash is stored
  - Revoked keys are rejected immediately with no grace period
  - Rate limiting is per-key, not per-IP, so shared infrastructure doesn't
  inflate one verifier's quota against another's
  
  Testing
  
  cd backend && npm test -- --testPathPattern=verifier-api-key
 closes #123
