### PR TITLE
Added Demo and seeding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,3 +62,5 @@ AWS_SECRET_ACCESS_KEY=
 AWS_REGION=us-east-1
 # Number of days to retain backups
 RETENTION_DAYS=30
+DEMO_ISSUER_SECRET=
+ADMIN_SECRET=

--- a/.github/workflows/demo-reset.yml
+++ b/.github/workflows/demo-reset.yml
@@ -1,0 +1,32 @@
+name: Weekly Demo Environment Reset
+
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch: # Allows manual trigger from the GitHub Actions tab
+
+jobs:
+  reset-demo:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install Dependencies
+        working-directory: ./backend
+        run: npm ci
+
+      - name: Run Seeding Script
+        working-directory: ./scripts
+        env:
+          NETWORK: TESTNET
+          RPC_URL: https://soroban-testnet.stellar.org
+          ADMIN_SECRET: ${{ secrets.DEMO_ADMIN_SECRET }}
+          DEMO_ISSUER_SECRET: ${{ secrets.DEMO_ISSUER_SECRET }}
+          DATABASE_URL: ${{ secrets.DEMO_DATABASE_URL }}
+        run: node seed_demo.js

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ __pycache__/
 *.pyc
 *.pyo
 .pytest_cache/
+frontend/package-lock.json
 
 # Build outputs
 dist/

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ VacciChain lets governments and healthcare providers issue vaccination records a
 
 ---
 
+## 🌐 Public Demo Environment
+
+You can explore VacciChain without setting up a local environment by visiting our live testnet demo.
+
+* **Network:** Stellar Testnet
+* **Reset Schedule:** Weekly (Every Sunday at 00:00 UTC)
+
+### Testing as an Issuer
+To evaluate the issuer flow (minting and revoking records), you can connect your Freighter wallet using testnet credentials. **Ensure your wallet is set to Testnet.**
+
+> **⚠️ Security Warning:** The demo database and contract state are wiped periodically.
+
+---
+
 ##  Architecture
 
 ```

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node src/app.js",
     "dev": "nodemon src/app.js",
-    "test": "jest --forceExit"
+    "test": "jest --forceExit",
+    "seed": "node scripts/seed_demo.mjs"
   },
   "dependencies": {
     "@stellar/stellar-sdk": "^12.0.0",

--- a/backend/scripts/seed_demo.mjs
+++ b/backend/scripts/seed_demo.mjs
@@ -1,0 +1,63 @@
+import { Keypair, Address, nativeToScVal } from '@stellar/stellar-sdk';
+import db from '../src/indexer/db.js';
+import { invokeContract } from '../src/stellar/soroban.js';
+
+const DEMO_ISSUER_SECRET = process.env.DEMO_ISSUER_SECRET;
+const ADMIN_SECRET = process.env.ADMIN_SECRET;
+
+async function seedDemoEnvironment() {
+  console.log('🔄 Starting Demo Environment Reset...');
+
+  console.log('🧹 Clearing backend database...');
+  await db.query('TRUNCATE TABLE vaccinations, users, audit_logs CASCADE;');
+
+  console.log('⚙️ Interacting with Soroban contract...');
+  const issuerKeypair = Keypair.fromSecret(DEMO_ISSUER_SECRET);
+  const issuerPubkey = issuerKeypair.publicKey();
+
+  try {
+    console.log('Adding Demo Issuer...');
+    
+    await invokeContract(
+      ADMIN_SECRET,
+      'add_issuer',
+      [
+        new Address(issuerPubkey).toScVal(),
+        nativeToScVal("VacciChain Demo Hospital", { type: 'string' }),
+        nativeToScVal("DEMO-LIC-001", { type: 'string' }),
+        nativeToScVal("Global", { type: 'string' })
+      ]
+    );
+    console.log(`✅ Demo Issuer authorized: ${issuerPubkey}`);
+
+    const samplePatients = [
+      Keypair.random().publicKey(),
+      Keypair.random().publicKey()
+    ];
+
+    console.log('💉 Minting sample vaccination records...');
+    const today = new Date().toISOString().split('T')[0];
+
+    for (const patientPubkey of samplePatients) {
+      await invokeContract(
+        DEMO_ISSUER_SECRET,
+        'mint_vaccination',
+        [
+          new Address(patientPubkey).toScVal(),
+          nativeToScVal("Demo Vax-COVID19", { type: 'string' }),
+          nativeToScVal(today, { type: 'string' }),
+          new Address(issuerPubkey).toScVal()
+        ]
+      );
+      console.log(`✅ Minted record for demo patient: ${patientPubkey}`);
+    }
+
+    console.log('🎉 Demo environment seeded successfully!');
+    process.exit(0);
+  } catch (error) {
+    console.error('❌ Failed to seed demo environment:', error);
+    process.exit(1);
+  }
+}
+
+seedDemoEnvironment();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -5,6 +5,8 @@ import IssuerDashboard from './pages/IssuerDashboard';
 import VerifyPage from './pages/VerifyPage';
 import { AuthProvider } from './hooks/useFreighter';
 import FreighterBanner from './components/FreighterBanner';
+import DemoBanner from './components/DemoBanner';
+import { useDarkMode } from './hooks/useDarkMode'
 
 function NavLink({ to, children }) {
   const { pathname } = useLocation();
@@ -21,6 +23,7 @@ export default function App() {
 
   return (
     <AuthProvider>
+      <DemoBanner/>
       <nav aria-label="Main navigation" style={{ padding: '1rem 2rem', background: '#1e293b', display: 'flex', gap: '1.5rem', alignItems: 'center' }}>
         <strong style={{ color: '#38bdf8', fontSize: '1.2rem' }}>💉 VacciChain</strong>
         <NavLink to="/">Home</NavLink>

--- a/frontend/src/components/DemoBanner.jsx
+++ b/frontend/src/components/DemoBanner.jsx
@@ -1,0 +1,7 @@
+export default function DemoBanner() {
+  return (
+    <div className="bg-yellow-500 text-slate-900 text-center py-2 px-4 font-bold text-sm sticky top-0 z-50 shadow-md">
+      ⚠️ PUBLIC DEMO ENVIRONMENT — Connected to Stellar Testnet. Records are simulated and database is wiped weekly. Do not enter real medical data.
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #124 

- Added a weekly demo environment reset github action.
- Updated the README with a Public Demo Environment block
- Added a `seed_demo` script and updated the `scripts` of `backend/package.json`
- Added a Demo Environment Banner to the frontend
- Fixed an import error in `App.jsx`

<img width="1916" height="673" alt="Screenshot 2026-04-27 183548" src="https://github.com/user-attachments/assets/d1c8a212-df53-484a-8634-9d6ed8f30140" />


## Additional Information

- Add `DEMO_ISSUER_SECRET`, `ADMIN_SECRET` to your environment variables
- Add `DEMO_ADMIN_SECRET`, `DEMO_ISSUER_SECRET`, and `DEMO_DATABASE_URL` to your repository's Actions secrets