### PR TITLE
feat: add uptime monitoring with health checks and alerting

### DIFF
--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,51 @@
+# VacciChain Uptime Monitoring
+
+Prometheus + Blackbox Exporter + Alertmanager + Grafana stack for health checks and alerting.
+
+## Services monitored
+
+| Service | Endpoint | Check |
+|---|---|---|
+| Backend (Node.js) | `http://backend:4000/health` | HTTP 200 + `"status":"ok"` |
+| Analytics (FastAPI) | `http://python-service:8001/health` | HTTP 200 + `"status":"ok"` |
+| Frontend (nginx) | `http://frontend:80` | HTTP 200 |
+| Staging backend | `$STAGING_BACKEND_URL/health` | HTTP 200 + `"status":"ok"` |
+
+## Alert rules
+
+| Alert | Condition | Severity | Fires after |
+|---|---|---|---|
+| `ServiceDown` | `probe_success == 0` | critical | 2 minutes |
+| `ServiceSlowResponse` | response > 3s | warning | 5 minutes |
+| `ServiceDegraded` | HTTP 503 | warning | 2 minutes |
+
+## Notification channels
+
+Configure via environment variables before starting:
+
+```bash
+export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/...
+export PAGERDUTY_ROUTING_KEY=...
+export ALERT_EMAIL=ops@example.com
+export SMTP_HOST=smtp.example.com
+export SMTP_USER=...
+export SMTP_PASSWORD=...
+```
+
+## Run
+
+```bash
+# Start monitoring stack alongside the main app
+docker compose -f docker-compose.yml -f monitoring/docker-compose.monitoring.yml up
+
+# Or standalone
+cd monitoring
+docker compose -f docker-compose.monitoring.yml up
+```
+
+## Dashboards
+
+- Grafana: http://localhost:3001 (admin / `$GRAFANA_PASSWORD`)
+- Prometheus: http://localhost:9090
+- Alertmanager: http://localhost:9093
+- Blackbox Exporter: http://localhost:9115

--- a/monitoring/alertmanager.yml
+++ b/monitoring/alertmanager.yml
@@ -1,0 +1,61 @@
+global:
+  resolve_timeout: 5m
+  # SMTP for email alerts — set via environment variables
+  smtp_smarthost: "${SMTP_HOST:-smtp.example.com}:587"
+  smtp_from: "alerts@vaccichain.example.com"
+  smtp_auth_username: "${SMTP_USER}"
+  smtp_auth_password: "${SMTP_PASSWORD}"
+
+route:
+  group_by: ["alertname", "instance"]
+  group_wait: 30s
+  group_interval: 5m
+  repeat_interval: 1h
+  receiver: default
+  routes:
+    - match:
+        severity: critical
+      receiver: critical
+      continue: true
+    - match:
+        severity: warning
+      receiver: warning
+
+receivers:
+  - name: default
+    slack_configs:
+      - api_url: "${SLACK_WEBHOOK_URL}"
+        channel: "#vaccichain-alerts"
+        title: "{{ .GroupLabels.alertname }}"
+        text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+        send_resolved: true
+
+  - name: critical
+    slack_configs:
+      - api_url: "${SLACK_WEBHOOK_URL}"
+        channel: "#vaccichain-alerts"
+        title: "🚨 CRITICAL: {{ .GroupLabels.alertname }}"
+        text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+        send_resolved: true
+    pagerduty_configs:
+      - routing_key: "${PAGERDUTY_ROUTING_KEY}"
+        description: "{{ range .Alerts }}{{ .Annotations.summary }}\n{{ end }}"
+    email_configs:
+      - to: "${ALERT_EMAIL:-ops@vaccichain.example.com}"
+        subject: "🚨 VacciChain CRITICAL: {{ .GroupLabels.alertname }}"
+        body: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+
+  - name: warning
+    slack_configs:
+      - api_url: "${SLACK_WEBHOOK_URL}"
+        channel: "#vaccichain-alerts"
+        title: "⚠️ WARNING: {{ .GroupLabels.alertname }}"
+        text: "{{ range .Alerts }}{{ .Annotations.description }}\n{{ end }}"
+        send_resolved: true
+
+inhibit_rules:
+  - source_match:
+      severity: critical
+    target_match:
+      severity: warning
+    equal: ["instance"]

--- a/monitoring/alerts.yml
+++ b/monitoring/alerts.yml
@@ -1,0 +1,38 @@
+groups:
+  - name: vaccichain_uptime
+    rules:
+      # Alert within 2 minutes of a service going down
+      - alert: ServiceDown
+        expr: probe_success == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "VacciChain service down: {{ $labels.instance }}"
+          description: >
+            {{ $labels.instance }} (env={{ $labels.env }}) has been unreachable
+            for more than 2 minutes.
+
+      # Warn if response time exceeds 3 seconds
+      - alert: ServiceSlowResponse
+        expr: probe_duration_seconds > 3
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Slow response: {{ $labels.instance }}"
+          description: >
+            {{ $labels.instance }} response time is {{ $value | humanizeDuration }},
+            exceeding the 3s threshold.
+
+      # Alert if health endpoint returns degraded status (503)
+      - alert: ServiceDegraded
+        expr: probe_http_status_code == 503
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "VacciChain service degraded: {{ $labels.instance }}"
+          description: >
+            {{ $labels.instance }} is returning HTTP 503 (degraded).
+            Soroban RPC may be unreachable.

--- a/monitoring/blackbox.yml
+++ b/monitoring/blackbox.yml
@@ -1,0 +1,22 @@
+modules:
+  http_2xx:
+    prober: http
+    timeout: 10s
+    http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_status_codes: [200]
+      method: GET
+      follow_redirects: true
+      preferred_ip_protocol: ip4
+
+  http_health:
+    prober: http
+    timeout: 10s
+    http:
+      valid_http_versions: ["HTTP/1.1", "HTTP/2.0"]
+      valid_status_codes: [200]
+      method: GET
+      follow_redirects: true
+      preferred_ip_protocol: ip4
+      fail_if_body_not_matches_regexp:
+        - '"status":"ok"'

--- a/monitoring/docker-compose.monitoring.yml
+++ b/monitoring/docker-compose.monitoring.yml
@@ -1,0 +1,51 @@
+# VacciChain Uptime Monitoring
+# Uses Prometheus Blackbox Exporter for HTTP health checks + Alertmanager for notifications.
+# Run with: docker compose -f monitoring/docker-compose.monitoring.yml up
+
+services:
+  blackbox:
+    image: prom/blackbox-exporter:v0.25.0
+    volumes:
+      - ./blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+    ports:
+      - "9115:9115"
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:v2.51.0
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - ./alerts.yml:/etc/prometheus/alerts.yml:ro
+      - prometheus_data:/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=15d
+    ports:
+      - "9090:9090"
+    restart: unless-stopped
+
+  alertmanager:
+    image: prom/alertmanager:v0.27.0
+    volumes:
+      - ./alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+    ports:
+      - "9093:9093"
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:10.4.0
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=${GRAFANA_PASSWORD:-admin}
+      - GF_USERS_ALLOW_SIGN_UP=false
+    volumes:
+      - grafana_data:/var/lib/grafana
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3001:3000"
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/monitoring/grafana/provisioning/dashboards/provider.yml
+++ b/monitoring/grafana/provisioning/dashboards/provider.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: VacciChain
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 30
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/monitoring/grafana/provisioning/dashboards/uptime.json
+++ b/monitoring/grafana/provisioning/dashboards/uptime.json
@@ -1,0 +1,67 @@
+{
+  "title": "VacciChain Service Health",
+  "uid": "vaccichain-uptime",
+  "schemaVersion": 38,
+  "refresh": "30s",
+  "panels": [
+    {
+      "id": 1,
+      "title": "Service Up/Down",
+      "type": "stat",
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 4 },
+      "targets": [
+        {
+          "expr": "probe_success",
+          "legendFormat": "{{ instance }}",
+          "datasource": "Prometheus"
+        }
+      ],
+      "options": {
+        "reduceOptions": { "calcs": ["lastNotNull"] },
+        "colorMode": "background",
+        "graphMode": "none",
+        "orientation": "auto"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [
+            { "type": "value", "options": { "0": { "text": "DOWN", "color": "red" }, "1": { "text": "UP", "color": "green" } } }
+          ],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": 0 }, { "color": "green", "value": 1 }] }
+        }
+      }
+    },
+    {
+      "id": 2,
+      "title": "Response Time (seconds)",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 4, "w": 24, "h": 8 },
+      "targets": [
+        {
+          "expr": "probe_duration_seconds",
+          "legendFormat": "{{ instance }}",
+          "datasource": "Prometheus"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": 0 }, { "color": "yellow", "value": 1 }, { "color": "red", "value": 3 }] }
+        }
+      }
+    },
+    {
+      "id": 3,
+      "title": "HTTP Status Code",
+      "type": "timeseries",
+      "gridPos": { "x": 0, "y": 12, "w": 24, "h": 6 },
+      "targets": [
+        {
+          "expr": "probe_http_status_code",
+          "legendFormat": "{{ instance }}",
+          "datasource": "Prometheus"
+        }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,72 @@
+global:
+  scrape_interval: 30s
+  evaluation_interval: 30s
+
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets: ["alertmanager:9093"]
+
+rule_files:
+  - /etc/prometheus/alerts.yml
+
+scrape_configs:
+  # ── VacciChain service health checks ──────────────────────────────────────
+  - job_name: vaccichain_health
+    metrics_path: /probe
+    params:
+      module: [http_health]
+    static_configs:
+      - targets:
+          - http://backend:4000/health        # Backend (Node.js)
+          - http://python-service:8001/health # Analytics (FastAPI)
+        labels:
+          env: local
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox:9115
+
+  # ── Frontend availability ──────────────────────────────────────────────────
+  - job_name: vaccichain_frontend
+    metrics_path: /probe
+    params:
+      module: [http_2xx]
+    static_configs:
+      - targets:
+          - http://frontend:80
+        labels:
+          env: local
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox:9115
+
+  # ── Staging / production endpoints (override via env vars or edit targets) ─
+  - job_name: vaccichain_staging
+    metrics_path: /probe
+    params:
+      module: [http_health]
+    static_configs:
+      - targets:
+          - ${STAGING_BACKEND_URL:-https://staging.vaccichain.example.com}/health
+        labels:
+          env: staging
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox:9115
+
+  # ── Blackbox exporter self-monitoring ─────────────────────────────────────
+  - job_name: blackbox
+    static_configs:
+      - targets: ["blackbox:9115"]


### PR DESCRIPTION
- Add Prometheus Blackbox Exporter probing all three service /health endpoints (backend, analytics, frontend)
- Add alert rules: ServiceDown fires within 2 min, ServiceSlowResponse at >3s, ServiceDegraded on HTTP 503
- Add Alertmanager config with Slack, PagerDuty, and email receivers
- Add Grafana dashboard (service up/down, response time, HTTP status)
- Add monitoring/docker-compose.monitoring.yml to run the stack
- Add monitoring/README.md with setup and configuration instructions

Closes #70

## Description

Please include a summary of the changes and related context.

Closes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Changes Made

- 
- 
- 

## Testing

Please describe the tests you ran and how to reproduce them:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

**Test Coverage:**
- 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests passed locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

If your changes include UI modifications, please add screenshots here.

## Additional Notes

Any additional information that reviewers should know.
