### PR TITLE
Feat/issues 110 114 116 120 combined

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,16 @@ RATE_LIMIT_SEP10=10
 # Max public verify requests per IP per minute (default: 60)
 RATE_LIMIT_VERIFY=60
 
+# ── Brute-force protection ────────────────────────────────────────────────────
+# Max failed /auth/verify attempts before blocking (default: 5)
+BRUTE_FORCE_MAX_ATTEMPTS=5
+
+# Sliding window for counting failures in milliseconds (default: 600000 = 10 min)
+BRUTE_FORCE_WINDOW_MS=600000
+
+# How long a blocked IP/wallet stays blocked in milliseconds (default: 900000 = 15 min)
+BRUTE_FORCE_BLOCK_MS=900000
+
 # ── Audit log ─────────────────────────────────────────────────────────────────
 # Path to append-only NDJSON audit log (default: ./audit.log)
 AUDIT_LOG_PATH=./audit.log

--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,10 @@ ANALYTICS_PORT=8001
 # Base URL the analytics service uses to reach the backend (default set by Compose)
 BACKEND_URL=http://backend:4000
 
+# API key required to access protected analytics endpoints (rates, issuers, anomalies)
+# Generate with: openssl rand -hex 32
+ANALYTICS_API_KEY=
+
 # ── Backup service ────────────────────────────────────────────────────────────
 # S3 Bucket for analytics DB backup
 S3_BUCKET_NAME=

--- a/README.md
+++ b/README.md
@@ -350,3 +350,15 @@ cd python-service && pytest
 ##  License
 
 MIT © VacciChain Contributors
+
+---
+
+## 🗺️ Roadmap
+
+| Milestone | Target | Focus |
+|-----------|--------|-------|
+| v0.1 — Testnet MVP | 2026-06-30 | Core contract, backend, frontend, CI |
+| v0.2 — Security Hardening | 2026-09-30 | Auth hardening, audit, onboarding |
+| v1.0 — Mainnet Launch | 2026-12-31 | Production deployment, compliance |
+
+See [docs/roadmap.md](docs/roadmap.md) for full milestone details, success criteria, and issue triage.

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -16,6 +16,7 @@ const adminRoutes = require('./routes/admin');
 const patientRoutes = require('./routes/patient');
 const consentRoutes = require('./routes/consent');
 const eventsRoutes = require('./routes/events');
+const onboardingRoutes = require('./routes/onboarding');
 const apiVersion = require('./middleware/apiVersion');
 const { getRpcServer } = require('./stellar/soroban');
 
@@ -51,6 +52,7 @@ v1.use('/admin', adminRoutes);
 v1.use('/patient', patientRoutes);
 v1.use('/patient', consentRoutes);
 v1.use('/events', eventsRoutes);
+v1.use('/onboarding', onboardingRoutes);
 app.use('/v1', v1);
 
 // Legacy unversioned routes — 308 redirect to /v1/ with Deprecation header

--- a/backend/src/indexer/db.js
+++ b/backend/src/indexer/db.js
@@ -33,6 +33,18 @@ const SCHEMA = `
     wallet       TEXT PRIMARY KEY,
     consented_at TEXT NOT NULL
   );
+
+  CREATE TABLE IF NOT EXISTS issuer_applications (
+    id             TEXT PRIMARY KEY,
+    wallet         TEXT NOT NULL UNIQUE,
+    name           TEXT NOT NULL,
+    license_number TEXT NOT NULL,
+    country        TEXT NOT NULL,
+    status         TEXT NOT NULL DEFAULT 'pending',
+    submitted_at   TEXT NOT NULL,
+    reviewed_at    TEXT,
+    reviewer_note  TEXT
+  );
 `;
 
 /** Persist in-memory DB to disk. */
@@ -144,7 +156,7 @@ function revokeApiKey(id) {
   flush();
 }
 
-module.exports = { initDb, upsertEvents, queryEvents, getLatestLedger, insertApiKey, getApiKeyByHash, listApiKeys, revokeApiKey, getConsent, recordConsent, hasConsented };
+module.exports = { initDb, upsertEvents, queryEvents, getLatestLedger, insertApiKey, getApiKeyByHash, listApiKeys, revokeApiKey, getConsent, recordConsent, hasConsented, insertIssuerApplication, getIssuerApplication, listIssuerApplications, updateIssuerApplicationStatus };
 
 // ── Patient consent ───────────────────────────────────────────────────────────
 
@@ -167,4 +179,47 @@ function getConsent(wallet) {
 
 function hasConsented(wallet) {
   return !!getConsent(wallet);
+}
+
+// ── Issuer onboarding applications ───────────────────────────────────────────
+
+function insertIssuerApplication({ id, wallet, name, license_number, country, submitted_at }) {
+  db.run(
+    `INSERT INTO issuer_applications (id, wallet, name, license_number, country, status, submitted_at)
+     VALUES (?,?,?,?,?,'pending',?)`,
+    [id, wallet, name, license_number, country, submitted_at]
+  );
+  flush();
+}
+
+function getIssuerApplication(id) {
+  const res = db.exec('SELECT * FROM issuer_applications WHERE id = ?', [id]);
+  if (!res.length) return null;
+  const { columns, values } = res[0];
+  const obj = {};
+  columns.forEach((col, i) => { obj[col] = values[0][i]; });
+  return obj;
+}
+
+function listIssuerApplications({ status } = {}) {
+  let sql = 'SELECT * FROM issuer_applications';
+  const params = [];
+  if (status) { sql += ' WHERE status = ?'; params.push(status); }
+  sql += ' ORDER BY submitted_at DESC';
+  const res = db.exec(sql, params);
+  if (!res.length) return [];
+  const { columns, values } = res[0];
+  return values.map(row => {
+    const obj = {};
+    columns.forEach((col, i) => { obj[col] = row[i]; });
+    return obj;
+  });
+}
+
+function updateIssuerApplicationStatus(id, { status, reviewer_note }) {
+  db.run(
+    'UPDATE issuer_applications SET status = ?, reviewed_at = ?, reviewer_note = ? WHERE id = ?',
+    [status, new Date().toISOString(), reviewer_note || null, id]
+  );
+  flush();
 }

--- a/backend/src/middleware/bruteForce.js
+++ b/backend/src/middleware/bruteForce.js
@@ -1,0 +1,94 @@
+/**
+ * Brute-force protection for /auth/verify.
+ *
+ * Tracks failed attempts per IP and per wallet address.
+ * After MAX_ATTEMPTS failures within WINDOW_MS, the IP/wallet is blocked
+ * for BLOCK_DURATION_MS and a block event is logged.
+ *
+ * Storage is in-process (Map). For multi-instance deployments, replace
+ * with a shared Redis store.
+ */
+
+const { audit } = require('./auditLog');
+const logger = require('../logger');
+
+const MAX_ATTEMPTS     = parseInt(process.env.BRUTE_FORCE_MAX_ATTEMPTS   || '5',      10);
+const WINDOW_MS        = parseInt(process.env.BRUTE_FORCE_WINDOW_MS      || '600000', 10); // 10 min
+const BLOCK_DURATION_MS = parseInt(process.env.BRUTE_FORCE_BLOCK_MS      || '900000', 10); // 15 min
+
+// Map<key, { count, windowStart, blockedUntil }>
+const store = new Map();
+
+function _getEntry(key) {
+  const now = Date.now();
+  let entry = store.get(key);
+  if (!entry || now - entry.windowStart > WINDOW_MS) {
+    entry = { count: 0, windowStart: now, blockedUntil: 0 };
+    store.set(key, entry);
+  }
+  return entry;
+}
+
+/**
+ * Returns true if the key is currently blocked.
+ */
+function isBlocked(key) {
+  const entry = store.get(key);
+  if (!entry) return false;
+  return Date.now() < entry.blockedUntil;
+}
+
+/**
+ * Record a failed attempt for a key.
+ * Blocks the key if MAX_ATTEMPTS is reached within the window.
+ */
+function recordFailure(key, meta = {}) {
+  const entry = _getEntry(key);
+  entry.count += 1;
+
+  if (entry.count >= MAX_ATTEMPTS) {
+    entry.blockedUntil = Date.now() + BLOCK_DURATION_MS;
+    logger.warn('brute-force block', { key, attempts: entry.count, ...meta });
+    audit({
+      actor: meta.wallet || key,
+      action: 'auth.brute_force_block',
+      result: 'blocked',
+      meta: { ip: meta.ip, wallet: meta.wallet, attempts: entry.count },
+    });
+  }
+}
+
+/**
+ * Clear the failure record for a key on successful auth.
+ */
+function recordSuccess(key) {
+  store.delete(key);
+}
+
+/**
+ * Express middleware that enforces brute-force limits on /auth/verify.
+ *
+ * Checks both the client IP and the wallet address (from request body).
+ * Returns 429 with retryAfter if either is blocked.
+ */
+function bruteForceGuard(req, res, next) {
+  const ip     = req.ip || req.socket?.remoteAddress || 'unknown';
+  // wallet may not be in body yet — we check again after body parse
+  const wallet = req.body?.public_key || req.body?.wallet || null;
+
+  const ipBlocked     = isBlocked(`ip:${ip}`);
+  const walletBlocked = wallet && isBlocked(`wallet:${wallet}`);
+
+  if (ipBlocked || walletBlocked) {
+    const entry = store.get(ipBlocked ? `ip:${ip}` : `wallet:${wallet}`);
+    const retryAfter = Math.ceil((entry.blockedUntil - Date.now()) / 1000);
+    return res.status(429).json({
+      error: 'Too many failed attempts. Try again later or contact support.',
+      retryAfter,
+    });
+  }
+
+  next();
+}
+
+module.exports = { bruteForceGuard, recordFailure, recordSuccess, isBlocked };

--- a/backend/src/routes/auth.js
+++ b/backend/src/routes/auth.js
@@ -6,6 +6,7 @@ const { buildChallenge, verifyChallenge } = require('../stellar/sep10');
 const { sep10Limiter } = require('../middleware/rateLimiter');
 const { audit } = require('../middleware/auditLog');
 const validate = require('../middleware/validate');
+const { bruteForceGuard, recordFailure, recordSuccess } = require('../middleware/bruteForce');
 
 const router = express.Router();
 
@@ -66,21 +67,26 @@ router.post('/sep10', sep10Limiter, validate(sep10Schema), async (req, res) => {
  * @returns {Object} 401 - Invalid signature or nonce mismatch
  * @throws {Error} 500 - Internal server error
  */
-router.post('/verify', validate(verifySchema), (req, res) => {
+router.post('/verify', validate(verifySchema), bruteForceGuard, (req, res) => {
   const { transaction, nonce } = req.body;
+  const ip = req.ip || req.socket?.remoteAddress || 'unknown';
 
   try {
     const publicKey = verifyChallenge(transaction, nonce);
+
+    // Clear failure counters on success
+    recordSuccess(`ip:${ip}`);
+    recordSuccess(`wallet:${publicKey}`);
 
     const role = publicKey === process.env.ADMIN_PUBLIC_KEY ? 'issuer' : 'patient';
     const now = Math.floor(Date.now() / 1000);
 
     const token = jwt.sign(
       {
-        sub: publicKey,       // SEP-10: subject is the authenticated Stellar account
+        sub: publicKey,
         iss: process.env.HOME_DOMAIN || 'localhost',
         iat: now,
-        wallet: publicKey,    // convenience claim used by authMiddleware
+        wallet: publicKey,
         role,
       },
       process.env.JWT_SECRET,
@@ -91,7 +97,18 @@ router.post('/verify', validate(verifySchema), (req, res) => {
 
     res.json({ token, wallet: publicKey, role });
   } catch (err) {
-    audit({ actor: 'unknown', action: 'auth.login', result: 'failure', meta: { error: err.message } });
+    // Attempt to extract wallet from the transaction for per-wallet tracking
+    let wallet = null;
+    try {
+      const tx = StellarSdk.TransactionBuilder.fromXDR(transaction, process.env.STELLAR_NETWORK_PASSPHRASE || 'Test SDF Network ; September 2015');
+      wallet = tx.source;
+    } catch (_) { /* ignore parse errors */ }
+
+    const ip = req.ip || req.socket?.remoteAddress || 'unknown';
+    recordFailure(`ip:${ip}`, { ip, wallet });
+    if (wallet) recordFailure(`wallet:${wallet}`, { ip, wallet });
+
+    audit({ actor: wallet || 'unknown', action: 'auth.login', result: 'failure', meta: { error: err.message } });
     res.status(401).json({ error: err.message });
   }
 });

--- a/backend/src/routes/onboarding.js
+++ b/backend/src/routes/onboarding.js
@@ -1,0 +1,114 @@
+/**
+ * Issuer onboarding routes.
+ *
+ * POST /v1/onboarding/apply       — healthcare provider submits application (requires patient/issuer JWT)
+ * GET  /v1/onboarding/applications — admin lists all applications (admin JWT required)
+ * POST /v1/onboarding/applications/:id/review — admin approves or rejects (admin JWT required)
+ */
+
+const express = require('express');
+const crypto = require('crypto');
+const { z } = require('zod');
+const authMiddleware = require('../middleware/auth');
+const validate = require('../middleware/validate');
+const { audit } = require('../middleware/auditLog');
+const { addIssuer } = require('../stellar/soroban');
+const {
+  insertIssuerApplication,
+  getIssuerApplication,
+  listIssuerApplications,
+  updateIssuerApplicationStatus,
+} = require('../indexer/db');
+
+const router = express.Router();
+
+function adminOnly(req, res, next) {
+  if (req.user?.role !== 'issuer') {
+    return res.status(403).json({ error: 'Admin access required' });
+  }
+  next();
+}
+
+const applySchema = z.object({
+  name:           z.string().min(2).max(120),
+  license_number: z.string().min(1).max(60),
+  country:        z.string().min(2).max(60),
+  wallet:         z.string().min(56).max(56),
+});
+
+const reviewSchema = z.object({
+  decision:      z.enum(['approved', 'rejected']),
+  reviewer_note: z.string().max(500).optional(),
+});
+
+/**
+ * POST /onboarding/apply
+ * Any authenticated user can submit an onboarding request.
+ */
+router.post('/apply', authMiddleware, validate(applySchema), async (req, res) => {
+  const { name, license_number, country, wallet } = req.body;
+
+  // Prevent duplicate applications from the same wallet
+  const existing = listIssuerApplications().find(a => a.wallet === wallet && a.status === 'pending');
+  if (existing) {
+    return res.status(409).json({ error: 'A pending application already exists for this wallet.' });
+  }
+
+  const id = crypto.randomUUID();
+  insertIssuerApplication({ id, wallet, name, license_number, country, submitted_at: new Date().toISOString() });
+
+  audit({ actor: req.user.wallet, action: 'onboarding.apply', result: 'submitted', meta: { id, wallet } });
+
+  res.status(201).json({ id, status: 'pending', message: 'Application submitted. You will be notified of the outcome.' });
+});
+
+/**
+ * GET /onboarding/applications
+ * Admin only — list all applications, optionally filtered by status.
+ */
+router.get('/applications', authMiddleware, adminOnly, (req, res) => {
+  const { status } = req.query;
+  const allowed = ['pending', 'approved', 'rejected'];
+  if (status && !allowed.includes(status)) {
+    return res.status(400).json({ error: `status must be one of: ${allowed.join(', ')}` });
+  }
+  res.json(listIssuerApplications({ status }));
+});
+
+/**
+ * POST /onboarding/applications/:id/review
+ * Admin only — approve or reject an application.
+ * On approval, the wallet is added to the contract issuer allowlist.
+ */
+router.post('/applications/:id/review', authMiddleware, adminOnly, validate(reviewSchema), async (req, res) => {
+  const application = getIssuerApplication(req.params.id);
+  if (!application) {
+    return res.status(404).json({ error: 'Application not found' });
+  }
+  if (application.status !== 'pending') {
+    return res.status(409).json({ error: `Application is already ${application.status}` });
+  }
+
+  const { decision, reviewer_note } = req.body;
+
+  if (decision === 'approved') {
+    try {
+      await addIssuer(application.wallet);
+    } catch (err) {
+      return res.status(502).json({ error: `Contract call failed: ${err.message}` });
+    }
+  }
+
+  updateIssuerApplicationStatus(req.params.id, { status: decision, reviewer_note });
+
+  audit({
+    actor: req.user.wallet,
+    action: `onboarding.${decision}`,
+    result: decision,
+    meta: { applicationId: req.params.id, applicantWallet: application.wallet },
+  });
+
+  res.json({ id: req.params.id, status: decision, wallet: application.wallet });
+});
+
+module.exports = router;

--- a/backend/src/stellar/soroban.js
+++ b/backend/src/stellar/soroban.js
@@ -151,4 +151,17 @@ async function simulateContract(method, args) {
   return sim.result?.retval;
 }
 
-module.exports = { getRpcServer, invokeContract, simulateContract };
+module.exports = { getRpcServer, invokeContract, simulateContract, addIssuer };
+
+/**
+ * Add a new issuer to the contract allowlist (admin-signed).
+ * @param {string} issuerWallet - Stellar public key to authorize as issuer
+ */
+async function addIssuer(issuerWallet) {
+  const adminSecret = process.env.ADMIN_SECRET_KEY;
+  if (!adminSecret) throw new Error('ADMIN_SECRET_KEY not configured');
+  const args = [StellarSdk.xdr.ScVal.scvAddress(
+    StellarSdk.Address.fromString(issuerWallet).toScAddress()
+  )];
+  return invokeContract(adminSecret, 'add_issuer', args);
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,83 @@
+# VacciChain Product Roadmap
+
+This document describes the planned milestones, their success criteria, and target dates.
+All existing issues are triaged and assigned to a milestone in the GitHub Milestones UI.
+
+---
+
+## Milestones
+
+### v0.1 — Testnet MVP
+**Target date:** 2026-06-30
+
+The first public release. Core functionality is working end-to-end on Stellar Testnet.
+
+**Success criteria:**
+- Soroban contract deployed to testnet with mint, verify, revoke, and issuer management
+- Backend REST API fully operational (auth, vaccination, verify, admin)
+- Frontend: patient dashboard, issuer dashboard, verify page, admin API key management
+- SEP-10 authentication working with Freighter wallet
+- Docker Compose stack runs with a single command
+- CI pipeline passing (lint, unit tests, contract tests)
+- Public demo environment live and reset weekly
+
+**Issues in scope:** #1–#50 (core contract, backend, frontend, CI)
+
+---
+
+### v0.2 — Security Hardening
+**Target date:** 2026-09-30
+
+Addresses security findings from internal review and prepares for external audit.
+
+**Success criteria:**
+- Analytics service authentication implemented (#114)
+- Brute-force protection on auth endpoints (#110)
+- Issuer onboarding workflow with admin approval (#120)
+- Rate limiting reviewed and tightened across all endpoints
+- Secrets management via AWS Secrets Manager in production
+- Contract audit completed; all critical/high findings resolved
+- Threat model reviewed and updated
+- Penetration test report reviewed
+
+**Issues in scope:** #51–#130 (security, auth hardening, onboarding)
+
+---
+
+### v1.0 — Mainnet Launch
+**Target date:** 2026-12-31
+
+Production-ready release on Stellar Mainnet.
+
+**Success criteria:**
+- All v0.2 security criteria met
+- Contract deployed to Stellar Mainnet
+- Staging environment validated against mainnet configuration
+- Backup and restore procedures tested
+- SLA and monitoring dashboards in place (Prometheus + Grafana)
+- Privacy policy and user guides published
+- Load testing completed (≥500 concurrent users)
+- Mainnet launch checklist signed off (see docs/mainnet-launch.md)
+
+**Issues in scope:** #131+ (mainnet, performance, compliance, documentation)
+
+---
+
+## Issue Triage
+
+| Issue | Title | Milestone |
+|-------|-------|-----------|
+| #110 | Brute-force protection on auth endpoints | v0.2 |
+| #114 | Analytics service authentication | v0.2 |
+| #116 | Product roadmap and milestone structure | v0.2 |
+| #120 | Issuer onboarding workflow | v0.2 |
+
+> All other open issues are triaged in GitHub Milestones. See the
+> [Milestones page](https://github.com/bigvictoh/VacciChain/milestones) for the full list.
+
+---
+
+## Contributing
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for how to pick up issues and submit PRs.
+Each issue should reference its milestone in the PR description.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,6 +4,7 @@ import PatientDashboard from './pages/PatientDashboard';
 import IssuerDashboard from './pages/IssuerDashboard';
 import VerifyPage from './pages/VerifyPage';
 import AdminDashboard from './pages/AdminDashboard';
+import IssuerOnboarding from './pages/IssuerOnboarding';
 import { AuthProvider } from './hooks/useFreighter';
 import { useDarkMode } from './hooks/useDarkMode';
 import FreighterBanner from './components/FreighterBanner';
@@ -33,6 +34,7 @@ export default function App() {
         <NavLink to="/issuer">Issue</NavLink>
         <NavLink to="/verify">Verify</NavLink>
         <NavLink to="/admin">Admin</NavLink>
+        <NavLink to="/apply">Apply as Issuer</NavLink>
       </nav>
       <FreighterBanner />
       <Routes>
@@ -41,6 +43,7 @@ export default function App() {
         <Route path="/issuer" element={<IssuerDashboard />} />
         <Route path="/verify" element={<VerifyPage />} />
         <Route path="/admin" element={<AdminDashboard />} />
+        <Route path="/apply" element={<IssuerOnboarding />} />
       </Routes>
     </AuthProvider>
   );

--- a/frontend/src/pages/AdminDashboard.jsx
+++ b/frontend/src/pages/AdminDashboard.jsx
@@ -8,28 +8,46 @@ const s = {
   td:      { padding: '0.5rem 0.75rem', borderBottom: '1px solid #1e293b', color: '#e2e8f0', wordBreak: 'break-all' },
   btn:     { padding: '0.45rem 1rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: '0.9rem' },
   btnDanger: { padding: '0.45rem 0.75rem', background: '#ef4444', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: '0.85rem' },
+  btnSuccess: { padding: '0.45rem 0.75rem', background: '#16a34a', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: '0.85rem', marginRight: '0.4rem' },
   input:   { padding: '0.5rem 0.75rem', background: '#1e293b', border: '1px solid #334155', borderRadius: 6, color: '#e2e8f0', fontSize: '0.9rem', flex: 1 },
   row:     { display: 'flex', gap: '0.75rem', marginBottom: '1.5rem', alignItems: 'center' },
   keyBox:  { marginTop: '1rem', padding: '0.75rem 1rem', background: '#0f172a', borderRadius: 8, color: '#4ade80', fontSize: '0.85rem', wordBreak: 'break-all' },
   badge:   (revoked) => ({ display: 'inline-block', padding: '0.15rem 0.5rem', borderRadius: 4, fontSize: '0.75rem', background: revoked ? '#7f1d1d' : '#14532d', color: revoked ? '#fca5a5' : '#86efac' }),
+  statusBadge: (status) => {
+    const map = { pending: ['#78350f', '#fde68a'], approved: ['#14532d', '#86efac'], rejected: ['#7f1d1d', '#fca5a5'] };
+    const [bg, color] = map[status] || ['#1e293b', '#94a3b8'];
+    return { display: 'inline-block', padding: '0.15rem 0.5rem', borderRadius: 4, fontSize: '0.75rem', background: bg, color };
+  },
+  section: { marginTop: '2.5rem' },
+  h3:      { color: 'var(--text)', marginBottom: '1rem', fontSize: '1.1rem' },
 };
 
 export default function AdminDashboard() {
   const { publicKey, role, connect, apiFetch } = useAuth();
-  const [keys, setKeys]       = useState([]);
-  const [label, setLabel]     = useState('');
-  const [newKey, setNewKey]   = useState(null);
-  const [error, setError]     = useState(null);
-  const [loading, setLoading] = useState(false);
+  const [keys, setKeys]             = useState([]);
+  const [label, setLabel]           = useState('');
+  const [newKey, setNewKey]         = useState(null);
+  const [error, setError]           = useState(null);
+  const [loading, setLoading]       = useState(false);
+  const [applications, setApps]     = useState([]);
+  const [reviewError, setReviewErr] = useState(null);
 
   const fetchKeys = useCallback(async () => {
     const res = await apiFetch('/v1/admin/api-keys');
     if (res.ok) setKeys(await res.json());
   }, [apiFetch]);
 
+  const fetchApplications = useCallback(async () => {
+    const res = await apiFetch('/v1/onboarding/applications');
+    if (res.ok) setApps(await res.json());
+  }, [apiFetch]);
+
   useEffect(() => {
-    if (publicKey && role === 'issuer') fetchKeys();
-  }, [publicKey, role, fetchKeys]);
+    if (publicKey && role === 'issuer') {
+      fetchKeys();
+      fetchApplications();
+    }
+  }, [publicKey, role, fetchKeys, fetchApplications]);
 
   if (!publicKey) {
     return (
@@ -72,6 +90,23 @@ export default function AdminDashboard() {
     if (!window.confirm('Revoke this API key? This cannot be undone.')) return;
     await apiFetch(`/v1/admin/api-keys/${id}`, { method: 'DELETE' });
     await fetchKeys();
+  };
+
+  const handleReview = async (id, decision) => {
+    const note = decision === 'rejected' ? window.prompt('Reason for rejection (optional):') : null;
+    setReviewErr(null);
+    try {
+      const res = await apiFetch(`/v1/onboarding/applications/${id}/review`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ decision, reviewer_note: note || undefined }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error);
+      await fetchApplications();
+    } catch (err) {
+      setReviewErr(err.message);
+    }
   };
 
   return (
@@ -132,6 +167,45 @@ export default function AdminDashboard() {
           </tbody>
         </table>
       )}
+
+      {/* ── Issuer Onboarding Applications ── */}
+      <div style={s.section}>
+        <h3 style={s.h3}>Issuer Onboarding Applications</h3>
+        {reviewError && <p style={{ color: '#f87171', marginBottom: '0.75rem' }}>{reviewError}</p>}
+        {applications.length === 0 ? (
+          <p style={{ color: '#64748b' }}>No applications yet.</p>
+        ) : (
+          <table style={s.table} aria-label="Issuer applications">
+            <thead>
+              <tr>
+                <th style={s.th}>Name</th>
+                <th style={s.th}>Country</th>
+                <th style={s.th}>License</th>
+                <th style={s.th}>Status</th>
+                <th style={s.th}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {applications.map((app) => (
+                <tr key={app.id}>
+                  <td style={s.td}>{app.name}</td>
+                  <td style={s.td}>{app.country}</td>
+                  <td style={s.td}>{app.license_number}</td>
+                  <td style={s.td}><span style={s.statusBadge(app.status)}>{app.status}</span></td>
+                  <td style={s.td}>
+                    {app.status === 'pending' && (
+                      <>
+                        <button style={s.btnSuccess} onClick={() => handleReview(app.id, 'approved')} aria-label={`Approve ${app.name}`}>Approve</button>
+                        <button style={s.btnDanger}  onClick={() => handleReview(app.id, 'rejected')} aria-label={`Reject ${app.name}`}>Reject</button>
+                      </>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
     </div>
   );
 }

--- a/frontend/src/pages/IssuerOnboarding.jsx
+++ b/frontend/src/pages/IssuerOnboarding.jsx
@@ -1,0 +1,104 @@
+import { useState } from 'react';
+import { useAuth } from '../hooks/useFreighter';
+
+const s = {
+  page:   { maxWidth: 520, width: '100%', margin: '2rem auto', padding: '0 1rem', boxSizing: 'border-box' },
+  field:  { display: 'flex', flexDirection: 'column', gap: '0.35rem', marginBottom: '1rem' },
+  label:  { color: '#94a3b8', fontSize: '0.85rem' },
+  input:  { padding: '0.5rem 0.75rem', background: '#1e293b', border: '1px solid #334155', borderRadius: 6, color: '#e2e8f0', fontSize: '0.9rem' },
+  btn:    { padding: '0.55rem 1.25rem', background: '#0ea5e9', color: '#fff', border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: '0.9rem', marginTop: '0.5rem' },
+  success:{ marginTop: '1rem', padding: '0.75rem 1rem', background: '#14532d', borderRadius: 8, color: '#86efac', fontSize: '0.9rem' },
+  error:  { marginTop: '0.5rem', color: '#f87171', fontSize: '0.9rem' },
+};
+
+export default function IssuerOnboarding() {
+  const { publicKey, connect, apiFetch } = useAuth();
+  const [form, setForm] = useState({ name: '', license_number: '', country: '' });
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(null);
+  const [error, setError] = useState(null);
+
+  if (!publicKey) {
+    return (
+      <div style={s.page}>
+        <h2 style={{ color: 'var(--text)', marginBottom: '1rem' }}>Apply for Issuer Status</h2>
+        <p style={{ color: '#94a3b8', marginBottom: '1rem' }}>
+          Connect your wallet to submit an onboarding request.
+        </p>
+        <button style={s.btn} onClick={connect}>Connect Wallet</button>
+      </div>
+    );
+  }
+
+  const handleChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      const res = await apiFetch('/v1/onboarding/apply', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...form, wallet: publicKey }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Submission failed');
+      setSuccess(data.message);
+      setForm({ name: '', license_number: '', country: '' });
+    } catch (err) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div style={s.page}>
+      <h2 style={{ color: 'var(--text)', marginBottom: '0.5rem' }}>Apply for Issuer Status</h2>
+      <p style={{ color: '#94a3b8', marginBottom: '1.5rem', fontSize: '0.9rem' }}>
+        Submit your details below. An admin will review your application and add you to the
+        contract allowlist upon approval.
+      </p>
+
+      <form onSubmit={handleSubmit}>
+        <div style={s.field}>
+          <label style={s.label} htmlFor="name">Organization / Provider Name</label>
+          <input
+            id="name" name="name" style={s.input} required
+            value={form.name} onChange={handleChange}
+            placeholder="City General Hospital"
+          />
+        </div>
+        <div style={s.field}>
+          <label style={s.label} htmlFor="license_number">License Number</label>
+          <input
+            id="license_number" name="license_number" style={s.input} required
+            value={form.license_number} onChange={handleChange}
+            placeholder="MED-12345"
+          />
+        </div>
+        <div style={s.field}>
+          <label style={s.label} htmlFor="country">Country</label>
+          <input
+            id="country" name="country" style={s.input} required
+            value={form.country} onChange={handleChange}
+            placeholder="Nigeria"
+          />
+        </div>
+        <div style={s.field}>
+          <label style={s.label}>Wallet Address</label>
+          <input style={{ ...s.input, color: '#64748b' }} value={publicKey} readOnly aria-readonly="true" />
+        </div>
+
+        <button style={s.btn} type="submit" disabled={loading} aria-disabled={loading}>
+          {loading ? 'Submitting…' : 'Submit Application'}
+        </button>
+      </form>
+
+      {error   && <p style={s.error} role="alert">{error}</p>}
+      {success && <div style={s.success} role="status">{success}</div>}
+    </div>
+  );
+}

--- a/python-service/auth.py
+++ b/python-service/auth.py
@@ -1,0 +1,62 @@
+"""
+Authentication middleware for the VacciChain analytics service.
+
+Supports two auth methods:
+  1. X-API-Key header — validated against ANALYTICS_API_KEY env var
+  2. Authorization: Bearer <jwt> — validated as an admin JWT (role == 'issuer')
+"""
+
+import os
+import jwt
+from fastapi import Header, HTTPException, Security
+from fastapi.security import APIKeyHeader, HTTPBearer, HTTPAuthorizationCredentials
+
+_api_key_scheme = APIKeyHeader(name="X-API-Key", auto_error=False)
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+def _get_analytics_api_key() -> str:
+    key = os.getenv("ANALYTICS_API_KEY", "")
+    if not key:
+        raise RuntimeError("ANALYTICS_API_KEY environment variable is not set")
+    return key
+
+
+def require_analytics_auth(
+    api_key: str | None = Security(_api_key_scheme),
+    credentials: HTTPAuthorizationCredentials | None = Security(_bearer_scheme),
+) -> dict:
+    """
+    FastAPI dependency that enforces authentication on analytics endpoints.
+
+    Accepts either:
+    - X-API-Key header matching ANALYTICS_API_KEY secret
+    - Bearer JWT with role == 'issuer' signed by JWT_SECRET
+
+    Returns the identity dict on success, raises HTTP 401 on failure.
+    """
+    # 1. API key check
+    if api_key:
+        expected = _get_analytics_api_key()
+        if api_key == expected:
+            return {"method": "api_key"}
+        raise HTTPException(status_code=401, detail="Invalid API key")
+
+    # 2. JWT check
+    if credentials:
+        token = credentials.credentials
+        jwt_secret = os.getenv("JWT_SECRET", "")
+        if not jwt_secret:
+            raise HTTPException(status_code=500, detail="JWT_SECRET not configured")
+        try:
+            payload = jwt.decode(token, jwt_secret, algorithms=["HS256"])
+        except jwt.ExpiredSignatureError:
+            raise HTTPException(status_code=401, detail="Token expired")
+        except jwt.InvalidTokenError:
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+        if payload.get("role") != "issuer":
+            raise HTTPException(status_code=403, detail="Admin role required")
+        return {"method": "jwt", "sub": payload.get("sub")}
+
+    raise HTTPException(status_code=401, detail="Authentication required")

--- a/python-service/main.py
+++ b/python-service/main.py
@@ -3,6 +3,9 @@ from contextlib import asynccontextmanager
 
 import structlog
 from fastapi import FastAPI, Request
+from slowapi import Limiter, _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.util import get_remote_address
 
 from routes.analytics import router as analytics_router
 from routes.batch import router as batch_router
@@ -31,6 +34,10 @@ async def lifespan(app: FastAPI):
 
 
 app = FastAPI(title="VacciChain Analytics", version="1.0.0", lifespan=lifespan)
+
+limiter = Limiter(key_func=get_remote_address)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
 app.include_router(analytics_router, prefix="/analytics")
 app.include_router(batch_router, prefix="/batch")

--- a/python-service/requirements.txt
+++ b/python-service/requirements.txt
@@ -6,3 +6,5 @@ structlog==24.1.0
 apscheduler==3.10.4
 pytest==8.1.1
 pytest-asyncio==0.23.6
+PyJWT==2.8.0
+slowapi==0.1.9

--- a/python-service/routes/analytics.py
+++ b/python-service/routes/analytics.py
@@ -1,9 +1,10 @@
 import os
 from collections import defaultdict
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 import httpx
+from auth import require_analytics_auth
 
-router = APIRouter(tags=["Analytics"])
+router = APIRouter(tags=["Analytics"], dependencies=[Depends(require_analytics_auth)])
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://backend:4000")
 # Anomaly threshold: flag issuers with more than this many mints in the dataset

--- a/python-service/routes/batch.py
+++ b/python-service/routes/batch.py
@@ -1,9 +1,12 @@
 import os
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 from schemas import BatchVerifyRequest, BatchVerifyResponse, WalletResult
 
 router = APIRouter(tags=["Batch"])
+limiter = Limiter(key_func=get_remote_address)
 
 BACKEND_URL = os.getenv("BACKEND_URL", "http://backend:4000")
 
@@ -22,9 +25,11 @@ BACKEND_URL = os.getenv("BACKEND_URL", "http://backend:4000")
     ),
     responses={
         400: {"description": "Request contains more than 100 wallets"},
+        429: {"description": "Rate limit exceeded"},
     },
 )
-async def batch_verify(request: BatchVerifyRequest):
+@limiter.limit("30/minute")
+async def batch_verify(request: Request, body: BatchVerifyRequest):
     """
     Verify vaccination status for multiple wallets in a single request.
 
@@ -46,12 +51,12 @@ async def batch_verify(request: BatchVerifyRequest):
         - No authentication required
         - Individual wallet lookup failures do not fail the entire request
     """
-    if len(request.wallets) > 100:
+    if len(body.wallets) > 100:
         raise HTTPException(status_code=400, detail="Maximum 100 wallets per request")
 
     results: list[WalletResult] = []
     async with httpx.AsyncClient() as client:
-        for wallet in request.wallets:
+        for wallet in body.wallets:
             try:
                 res = await client.get(f"{BACKEND_URL}/verify/{wallet}", timeout=10)
                 data = res.json()


### PR DESCRIPTION
 Add bruteForce.js middleware tracking failures per IP and per wallet
- After 5 failed /auth/verify attempts in 10 min, block for 15 min (429)
- Block events logged via audit log and logger.warn for alerting
- recordSuccess() clears counters on successful login
- Add BRUTE_FORCE_MAX_ATTEMPTS, BRUTE_FORCE_WINDOW_MS, BRUTE_FORCE_BLOCK_MS env vars

Closes #110
closes #114 
closes #116 
closes #120