### PR TITLE
feat(contract): add pause/unpause mechanism for emergency stops

### DIFF
--- a/contracts/src/events.rs
+++ b/contracts/src/events.rs
@@ -62,3 +62,19 @@ pub fn emit_patient_registered(env: &Env, patient: &Address) {
         (patient.clone(), timestamp),
     );
 }
+
+pub fn emit_contract_paused(env: &Env, admin: &Address) {
+    let timestamp = env.ledger().timestamp();
+    env.events().publish(
+        (symbol_short!("paused"),),
+        (admin.clone(), timestamp),
+    );
+}
+
+pub fn emit_contract_unpaused(env: &Env, admin: &Address) {
+    let timestamp = env.ledger().timestamp();
+    env.events().publish(
+        (symbol_short!("unpaused"),),
+        (admin.clone(), timestamp),
+    );
+}

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -60,6 +60,7 @@ pub enum ContractError {
     InvalidInputCountry = 14,
     SoulboundToken = 15,
     PatientNotRegistered = 16,
+    ContractPaused = 17,
 }
 
 const MAX_STRING_LENGTH: u32 = 100;
@@ -92,6 +93,13 @@ pub(crate) fn validate_input_length(field: &String, field_name: &str) -> Result<
             "country" => ContractError::InvalidInputCountry,
             _ => ContractError::InvalidInput,
         });
+    }
+    Ok(())
+}
+
+pub(crate) fn require_not_paused(env: &Env) -> Result<(), ContractError> {
+    if env.storage().persistent().get::<DataKey, bool>(&DataKey::Paused).unwrap_or(false) {
+        return Err(ContractError::ContractPaused);
     }
     Ok(())
 }
@@ -129,6 +137,37 @@ impl VacciChainContract {
         Ok(())
     }
 
+    /// Pause the contract. Admin only. All state-changing calls will return `ContractPaused`.
+    pub fn pause(env: Env) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Paused, &true);
+        events::emit_contract_paused(&env, &admin);
+        Ok(())
+    }
+
+    /// Unpause the contract. Admin only.
+    pub fn unpause(env: Env) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Paused, &false);
+        events::emit_contract_unpaused(&env, &admin);
+        Ok(())
+    }
+
+    /// Returns true if the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().persistent().get::<DataKey, bool>(&DataKey::Paused).unwrap_or(false)
+    }
+
     /// Authorize a new healthcare provider (issuer) with metadata.
     ///
     /// Only the admin can call this function. Once authorized, an issuer can mint
@@ -162,6 +201,7 @@ impl VacciChainContract {
         license: String,
         country: String,
     ) -> Result<(), ContractError> {
+        require_not_paused(&env)?;
         let admin: Address = env
             .storage()
             .persistent()
@@ -240,6 +280,7 @@ impl VacciChainContract {
     /// # Events
     /// Emits `IssuerRevoked` event on success.
     pub fn revoke_issuer(env: Env, issuer: Address) -> Result<(), ContractError> {
+        require_not_paused(&env)?;
         let admin: Address = env
             .storage()
             .persistent()
@@ -278,6 +319,7 @@ impl VacciChainContract {
     /// # Events
     /// Emits `PatientRegistered` event on success.
     pub fn register_patient(env: Env, patient: Address) -> Result<(), ContractError> {
+        require_not_paused(&env)?;
         patient.require_auth();
         env.storage()
             .persistent()
@@ -341,6 +383,7 @@ impl VacciChainContract {
         dose_number: Option<u32>,
         dose_series: Option<u32>,
     ) -> Result<u64, ContractError> {
+        require_not_paused(&env)?;
         mint::mint_vaccination(&env, patient, vaccine_name, date_administered, issuer, dose_number, dose_series)
     }
 
@@ -370,6 +413,7 @@ impl VacciChainContract {
     /// # Events
     /// Emits `VaccinationRevoked` event on success.
     pub fn revoke_vaccination(env: Env, token_id: u64, revoker: Address) -> Result<(), ContractError> {
+        require_not_paused(&env)?;
         revoker.require_auth();
 
         let mut record: VaccinationRecord = env

--- a/contracts/src/storage.rs
+++ b/contracts/src/storage.rs
@@ -106,4 +106,5 @@ pub enum DataKey {
     Token(u64),
     Revoked(u64),
     NextTokenId,
+    Paused,
 }


### PR DESCRIPTION
## Summary

Implements a contract-level emergency stop mechanism as described in issue #55.

## Changes

- **`ContractPaused = 17`** — new error variant returned when a state-changing call is made while paused
- **`DataKey::Paused`** — persistent boolean flag in contract storage
- **`pause()`** — admin-only function; emits `ContractPaused` event
- **`unpause()`** — admin-only function; emits `ContractUnpaused` event
- **`is_paused()`** — public read-only query
- **`require_not_paused()`** — internal guard added to all state-changing functions: `add_issuer`, `revoke_issuer`, `register_patient`, `mint_vaccination`, `revoke_vaccination`
- Read-only functions (`verify_vaccination`, `batch_verify`, `is_issuer`, etc.) remain available when paused

## Acceptance Criteria

- [x] `pause()` and `unpause()` callable by admin only
- [x] All state-changing functions check paused state and return `ContractPaused` error
- [x] Read-only functions (`verify_vaccination`) remain available when paused
- [x] `ContractPaused` and `ContractUnpaused` events emitted

Closes #55