### PR TITLE
test(contract): add security invariant tests

### DIFF
--- a/contracts/src/events.rs
+++ b/contracts/src/events.rs
@@ -62,3 +62,19 @@ pub fn emit_patient_registered(env: &Env, patient: &Address) {
         (patient.clone(), timestamp),
     );
 }
+
+pub fn emit_contract_paused(env: &Env, admin: &Address) {
+    let timestamp = env.ledger().timestamp();
+    env.events().publish(
+        (symbol_short!("paused"),),
+        (admin.clone(), timestamp),
+    );
+}
+
+pub fn emit_contract_unpaused(env: &Env, admin: &Address) {
+    let timestamp = env.ledger().timestamp();
+    env.events().publish(
+        (symbol_short!("unpaused"),),
+        (admin.clone(), timestamp),
+    );
+}

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -17,6 +17,9 @@ mod upgrade_tests;
 #[cfg(test)]
 mod property_tests;
 
+#[cfg(test)]
+mod security_invariant_tests;
+
 use soroban_sdk::{contract, contractimpl, contracterror, Address, BytesN, Env, String, Vec, IntoVal};
 use storage::{DataKey, IssuerRecord, VaccinationRecord, hash_address, compute_token_id};
 use verify::DoseStatus;

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -60,6 +60,7 @@ pub enum ContractError {
     InvalidInputCountry = 14,
     SoulboundToken = 15,
     PatientNotRegistered = 16,
+    ContractPaused = 17,
 }
 
 const MAX_STRING_LENGTH: u32 = 100;
@@ -92,6 +93,13 @@ pub(crate) fn validate_input_length(field: &String, field_name: &str) -> Result<
             "country" => ContractError::InvalidInputCountry,
             _ => ContractError::InvalidInput,
         });
+    }
+    Ok(())
+}
+
+pub(crate) fn require_not_paused(env: &Env) -> Result<(), ContractError> {
+    if env.storage().persistent().get::<DataKey, bool>(&DataKey::Paused).unwrap_or(false) {
+        return Err(ContractError::ContractPaused);
     }
     Ok(())
 }
@@ -129,6 +137,37 @@ impl VacciChainContract {
         Ok(())
     }
 
+    /// Pause the contract. Admin only. All state-changing calls will return `ContractPaused`.
+    pub fn pause(env: Env) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Paused, &true);
+        events::emit_contract_paused(&env, &admin);
+        Ok(())
+    }
+
+    /// Unpause the contract. Admin only.
+    pub fn unpause(env: Env) -> Result<(), ContractError> {
+        let admin: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Admin)
+            .ok_or(ContractError::NotInitialized)?;
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Paused, &false);
+        events::emit_contract_unpaused(&env, &admin);
+        Ok(())
+    }
+
+    /// Returns true if the contract is currently paused.
+    pub fn is_paused(env: Env) -> bool {
+        env.storage().persistent().get::<DataKey, bool>(&DataKey::Paused).unwrap_or(false)
+    }
+
     /// Authorize a new healthcare provider (issuer) with metadata.
     ///
     /// Only the admin can call this function. Once authorized, an issuer can mint
@@ -162,6 +201,7 @@ impl VacciChainContract {
         license: String,
         country: String,
     ) -> Result<(), ContractError> {
+        require_not_paused(&env)?;
         let admin: Address = env
             .storage()
             .persistent()
@@ -240,6 +280,7 @@ impl VacciChainContract {
     /// # Events
     /// Emits `IssuerRevoked` event on success.
     pub fn revoke_issuer(env: Env, issuer: Address) -> Result<(), ContractError> {
+        require_not_paused(&env)?;
         let admin: Address = env
             .storage()
             .persistent()
@@ -278,6 +319,7 @@ impl VacciChainContract {
     /// # Events
     /// Emits `PatientRegistered` event on success.
     pub fn register_patient(env: Env, patient: Address) -> Result<(), ContractError> {
+        require_not_paused(&env)?;
         patient.require_auth();
         env.storage()
             .persistent()
@@ -341,6 +383,7 @@ impl VacciChainContract {
         dose_number: Option<u32>,
         dose_series: Option<u32>,
     ) -> Result<u64, ContractError> {
+        require_not_paused(&env)?;
         mint::mint_vaccination(&env, patient, vaccine_name, date_administered, issuer, dose_number, dose_series)
     }
 
@@ -370,6 +413,7 @@ impl VacciChainContract {
     /// # Events
     /// Emits `VaccinationRevoked` event on success.
     pub fn revoke_vaccination(env: Env, token_id: u64, revoker: Address) -> Result<(), ContractError> {
+        require_not_paused(&env)?;
         revoker.require_auth();
 
         let mut record: VaccinationRecord = env

--- a/contracts/src/security_invariant_tests.rs
+++ b/contracts/src/security_invariant_tests.rs
@@ -1,0 +1,272 @@
+#![cfg(test)]
+
+//! Security invariant tests (Issue #96)
+//!
+//! Verifies critical security properties that must hold on every change:
+//! - Non-issuer cannot mint
+//! - Transfer always fails regardless of caller/recipient
+//! - Non-admin cannot add or revoke issuers
+//! - Paused contract rejects all state-changing calls
+
+use soroban_sdk::{testutils::Address as _, Env, String};
+use crate::{VacciChainContract, VacciChainContractClient, ContractError};
+
+fn setup() -> (Env, VacciChainContractClient<'static>, soroban_sdk::Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(VacciChainContract, ());
+    let client = VacciChainContractClient::new(&env, &contract_id);
+    let admin = soroban_sdk::Address::generate(&env);
+    client.initialize(&admin).unwrap();
+    (env, client, admin)
+}
+
+fn add_issuer(env: &Env, client: &VacciChainContractClient, issuer: &soroban_sdk::Address) {
+    client.add_issuer(
+        issuer,
+        &String::from_str(env, "Test Hospital"),
+        &String::from_str(env, "LIC-001"),
+        &String::from_str(env, "USA"),
+    ).unwrap();
+}
+
+// ── Non-issuer cannot mint ────────────────────────────────────────────────────
+
+#[test]
+fn invariant_non_issuer_cannot_mint() {
+    let (env, client, _admin) = setup();
+    let non_issuer = soroban_sdk::Address::generate(&env);
+    let patient = soroban_sdk::Address::generate(&env);
+
+    let result = client.try_mint_vaccination(
+        &patient,
+        &String::from_str(&env, "COVID-19"),
+        &String::from_str(&env, "2024-01-15"),
+        &non_issuer,
+        &None::<u32>,
+        &None::<u32>,
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+#[test]
+fn invariant_revoked_issuer_cannot_mint() {
+    let (env, client, _admin) = setup();
+    let issuer = soroban_sdk::Address::generate(&env);
+    let patient = soroban_sdk::Address::generate(&env);
+
+    add_issuer(&env, &client, &issuer);
+    client.revoke_issuer(&issuer).unwrap();
+
+    let result = client.try_mint_vaccination(
+        &patient,
+        &String::from_str(&env, "COVID-19"),
+        &String::from_str(&env, "2024-01-15"),
+        &issuer,
+        &None::<u32>,
+        &None::<u32>,
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::Unauthorized)));
+}
+
+// ── Transfer always fails ─────────────────────────────────────────────────────
+
+#[test]
+fn invariant_transfer_always_fails() {
+    let (env, client, _admin) = setup();
+    let from = soroban_sdk::Address::generate(&env);
+    let to = soroban_sdk::Address::generate(&env);
+
+    let result = client.try_transfer(&from, &to, &1u64);
+    assert_eq!(result, Err(Ok(ContractError::SoulboundToken)));
+}
+
+#[test]
+fn invariant_transfer_fails_even_for_admin() {
+    let (env, client, admin) = setup();
+    let to = soroban_sdk::Address::generate(&env);
+
+    let result = client.try_transfer(&admin, &to, &1u64);
+    assert_eq!(result, Err(Ok(ContractError::SoulboundToken)));
+}
+
+#[test]
+fn invariant_transfer_fails_for_any_token_id() {
+    let (env, client, _admin) = setup();
+    let issuer = soroban_sdk::Address::generate(&env);
+    let patient = soroban_sdk::Address::generate(&env);
+    let recipient = soroban_sdk::Address::generate(&env);
+
+    add_issuer(&env, &client, &issuer);
+    let token_id = client.mint_vaccination(
+        &patient,
+        &String::from_str(&env, "COVID-19"),
+        &String::from_str(&env, "2024-01-15"),
+        &issuer,
+        &None::<u32>,
+        &None::<u32>,
+    );
+
+    let result = client.try_transfer(&patient, &recipient, &token_id);
+    assert_eq!(result, Err(Ok(ContractError::SoulboundToken)));
+}
+
+// ── Non-admin cannot add or revoke issuers ────────────────────────────────────
+
+#[test]
+fn invariant_non_admin_cannot_add_issuer() {
+    let (env, client, _admin) = setup();
+    let non_admin = soroban_sdk::Address::generate(&env);
+    let issuer = soroban_sdk::Address::generate(&env);
+
+    // Override mock_all_auths to only authorize non_admin
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &non_admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "add_issuer",
+            args: (
+                issuer.clone(),
+                String::from_str(&env, "Hospital"),
+                String::from_str(&env, "LIC"),
+                String::from_str(&env, "USA"),
+            ).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_add_issuer(
+        &issuer,
+        &String::from_str(&env, "Hospital"),
+        &String::from_str(&env, "LIC"),
+        &String::from_str(&env, "USA"),
+    );
+
+    assert!(result.is_err(), "Non-admin should not be able to add an issuer");
+}
+
+#[test]
+fn invariant_non_admin_cannot_revoke_issuer() {
+    let (env, client, _admin) = setup();
+    let issuer = soroban_sdk::Address::generate(&env);
+    let non_admin = soroban_sdk::Address::generate(&env);
+
+    // Add issuer as admin first
+    add_issuer(&env, &client, &issuer);
+    assert!(client.is_issuer(&issuer));
+
+    // Attempt revoke as non-admin
+    env.mock_auths(&[soroban_sdk::testutils::MockAuth {
+        address: &non_admin,
+        invoke: &soroban_sdk::testutils::MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "revoke_issuer",
+            args: (issuer.clone(),).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_revoke_issuer(&issuer);
+    assert!(result.is_err(), "Non-admin should not be able to revoke an issuer");
+}
+
+// ── Paused contract rejects all state-changing calls ─────────────────────────
+
+#[test]
+fn invariant_paused_contract_rejects_mint() {
+    let (env, client, _admin) = setup();
+    let issuer = soroban_sdk::Address::generate(&env);
+    let patient = soroban_sdk::Address::generate(&env);
+
+    add_issuer(&env, &client, &issuer);
+    client.pause().unwrap();
+
+    let result = client.try_mint_vaccination(
+        &patient,
+        &String::from_str(&env, "COVID-19"),
+        &String::from_str(&env, "2024-01-15"),
+        &issuer,
+        &None::<u32>,
+        &None::<u32>,
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+}
+
+#[test]
+fn invariant_paused_contract_rejects_add_issuer() {
+    let (env, client, _admin) = setup();
+    let issuer = soroban_sdk::Address::generate(&env);
+
+    client.pause().unwrap();
+
+    let result = client.try_add_issuer(
+        &issuer,
+        &String::from_str(&env, "Hospital"),
+        &String::from_str(&env, "LIC"),
+        &String::from_str(&env, "USA"),
+    );
+
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+}
+
+#[test]
+fn invariant_paused_contract_rejects_revoke_issuer() {
+    let (env, client, _admin) = setup();
+    let issuer = soroban_sdk::Address::generate(&env);
+
+    add_issuer(&env, &client, &issuer);
+    client.pause().unwrap();
+
+    let result = client.try_revoke_issuer(&issuer);
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+}
+
+#[test]
+fn invariant_paused_contract_rejects_register_patient() {
+    let (env, client, _admin) = setup();
+    let patient = soroban_sdk::Address::generate(&env);
+
+    client.pause().unwrap();
+
+    let result = client.try_register_patient(&patient);
+    assert_eq!(result, Err(Ok(ContractError::ContractPaused)));
+}
+
+#[test]
+fn invariant_paused_contract_allows_verify() {
+    let (env, client, _admin) = setup();
+    let wallet = soroban_sdk::Address::generate(&env);
+
+    client.pause().unwrap();
+
+    // verify_vaccination must still work when paused
+    let (vaccinated, records, _) = client.verify_vaccination(&wallet);
+    assert!(!vaccinated);
+    assert_eq!(records.len(), 0);
+}
+
+#[test]
+fn invariant_unpause_restores_minting() {
+    let (env, client, _admin) = setup();
+    let issuer = soroban_sdk::Address::generate(&env);
+    let patient = soroban_sdk::Address::generate(&env);
+
+    add_issuer(&env, &client, &issuer);
+    client.pause().unwrap();
+    client.unpause().unwrap();
+
+    // Should succeed after unpause
+    let result = client.try_mint_vaccination(
+        &patient,
+        &String::from_str(&env, "COVID-19"),
+        &String::from_str(&env, "2024-01-15"),
+        &issuer,
+        &None::<u32>,
+        &None::<u32>,
+    );
+
+    assert!(result.is_ok(), "Minting should succeed after unpause");
+}

--- a/contracts/src/storage.rs
+++ b/contracts/src/storage.rs
@@ -106,4 +106,5 @@ pub enum DataKey {
     Token(u64),
     Revoked(u64),
     NextTokenId,
+    Paused,
 }


### PR DESCRIPTION
## Summary

Adds dedicated security invariant tests for the Soroban contract as described in issue #96.

## New file: `contracts/src/security_invariant_tests.rs`

### Tests added

| Test | Invariant |
|------|-----------|
| `invariant_non_issuer_cannot_mint` | Any address not in the allowlist is rejected with `Unauthorized` |
| `invariant_revoked_issuer_cannot_mint` | Revoked issuers cannot mint |
| `invariant_transfer_always_fails` | `SoulboundToken` error for any transfer attempt |
| `invariant_transfer_fails_even_for_admin` | Admin cannot transfer either |
| `invariant_transfer_fails_for_any_token_id` | Real minted token IDs also cannot be transferred |
| `invariant_non_admin_cannot_add_issuer` | Non-admin auth rejected on `add_issuer` |
| `invariant_non_admin_cannot_revoke_issuer` | Non-admin auth rejected on `revoke_issuer` |
| `invariant_paused_contract_rejects_mint` | `ContractPaused` returned when paused |
| `invariant_paused_contract_rejects_add_issuer` | `ContractPaused` returned when paused |
| `invariant_paused_contract_rejects_revoke_issuer` | `ContractPaused` returned when paused |
| `invariant_paused_contract_rejects_register_patient` | `ContractPaused` returned when paused |
| `invariant_paused_contract_allows_verify` | `verify_vaccination` works while paused |
| `invariant_unpause_restores_minting` | Minting succeeds after unpause |

Note: pause/unpause implementation is included (cherry-picked from #219) as the paused-contract tests depend on it.

## Acceptance Criteria

- [x] Test: non-issuer cannot mint
- [x] Test: transfer always fails regardless of caller and recipient
- [x] Test: non-admin cannot add or revoke issuers
- [x] Test: paused contract rejects all state-changing calls

Closes #96