### PR TITLE
test: add integration coverage for public verify endpoint

### DIFF
--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -17,13 +17,13 @@ const eventsRoutes = require('./routes/events');
 
 const patientRoutes = require('./routes/patient');
 const consentRoutes = require('./routes/consent');
-const eventsRoutes = require('./routes/events');
 const onboardingRoutes = require('./routes/onboarding');
 const apiVersion = require('./middleware/apiVersion');
 const { getRpcServer } = require('./stellar/soroban');
 
 const requestId = require('./middleware/requestId');
 const { sanitizeInputs } = require('./middleware/sanitize');
+const securityHeaders = require('./middleware/securityHeaders');
 
 const app = express();
 const allowedOrigins = (process.env.ALLOWED_ORIGINS || '').split(',').map(o => o.trim()).filter(Boolean);

--- a/backend/src/routes/verify.js
+++ b/backend/src/routes/verify.js
@@ -10,6 +10,9 @@ const { audit } = require('../middleware/auditLog');
 
 const router = express.Router();
 
+const verifyCache = new Map();
+const CACHE_TTL = 30 * 1000; // 30 seconds
+
 /**
  * Try JWT first; if no Authorization header, fall through to API key auth.
  * One of the two must succeed — otherwise 401.
@@ -86,10 +89,28 @@ router.get(
     const { wallet } = req.params;
     const actor = req.verifier ? `apikey:${req.verifier.id}` : (req.user?.wallet ?? 'unknown');
 
+    const now = Date.now();
+    const cached = verifyCache.get(wallet);
+    if (cached && (now - cached.timestamp < CACHE_TTL)) {
+      return res.json({
+        wallet,
+        vaccinated: cached.vaccinated,
+        verified: cached.vaccinated,
+        record_count: cached.records.length,
+        records: cached.records
+      });
+    }
+
     try {
       const args = [StellarSdk.Address.fromString(wallet).toScVal()];
       const result = await simulateContract('verify_vaccination', args);
       const [vaccinated, records] = StellarSdk.scValToNative(result);
+
+      verifyCache.set(wallet, {
+        vaccinated,
+        records,
+        timestamp: now
+      });
 
       audit({
         actor,
@@ -99,13 +120,20 @@ router.get(
         meta: req.verifier ? { verifier_label: req.verifier.label } : {},
       });
 
-      res.json({ wallet, vaccinated, record_count: records.length, records });
+      res.json({ wallet, vaccinated, verified: vaccinated, record_count: records.length, records });
     } catch (err) {
       const errorMessage = resolveContractErrorMessage(err);
       audit({ actor, action: 'verify.lookup', target: wallet, result: 'failure', meta: { error: errorMessage } });
-      res.status(500).json({ error: errorMessage });
+      
+      const isTimeout = err.message && (
+        err.message.toLowerCase().includes('timeout') ||
+        err.message.toLowerCase().includes('deadline') ||
+        err.message.toLowerCase().includes('abort')
+      );
+      res.status(isTimeout ? 503 : 500).json({ error: errorMessage });
     }
   }
 );
 
+router.verifyCache = verifyCache;
 module.exports = router;

--- a/backend/tests/verify-integration.test.js
+++ b/backend/tests/verify-integration.test.js
@@ -1,0 +1,153 @@
+const request = require('supertest');
+const jwt = require('jsonwebtoken');
+
+// Mock jwtKeys to support JWT authentication for verify endpoints without implementing/changing jwtKeys.js
+jest.mock('../src/jwtKeys', () => ({
+  getVerificationKeys: () => [{ kid: '1', secret: 'test-jwt-secret' }],
+  getSigningKey: () => ({ kid: '1', secret: 'test-jwt-secret' }),
+}));
+
+// Mock Soroban RPC responses
+jest.mock('../src/stellar/soroban', () => {
+  const sdk = require('@stellar/stellar-sdk');
+  return {
+    simulateContract: jest.fn(),
+    getRpcServer: jest.fn().mockReturnValue({ getHealth: jest.fn().mockResolvedValue({}) }),
+  };
+});
+
+const app = require('../src/app');
+const StellarSdk = require('@stellar/stellar-sdk');
+const { simulateContract } = require('../src/stellar/soroban');
+const verifyRouter = require('../src/routes/verify');
+
+const VALID_WALLET = 'GA3AUY2XRF6S7R73ABSLJMKG4R2NQGRUFPEJUGCANMBAAXI4MTBS6AQU';
+// Generate valid Stellar public keys to pass regex and SDK base32 verification checks
+const UNVACCINATED_WALLET = StellarSdk.Keypair.random().publicKey();
+
+describe('Integration Tests - Public Verify Endpoint (GET /v1/verify/:wallet)', () => {
+  let validToken;
+
+  beforeAll(() => {
+    validToken = jwt.sign(
+      {
+        publicKey: VALID_WALLET,
+        role: 'patient',
+        sub: VALID_WALLET,
+        wallet: VALID_WALLET,
+      },
+      'test-jwt-secret',
+      { expiresIn: '1h', keyid: '1' }
+    );
+  });
+
+  beforeEach(() => {
+    // Reset mock implementations and queue state between tests to avoid carryover
+    simulateContract.mockReset();
+    // Clear in-memory cache between tests
+    verifyRouter.verifyCache.clear();
+  });
+
+  it('Test: valid vaccinated wallet returns { verified: true, records: [...] }', async () => {
+    // Mock simulation returning [true, [records]]
+    const mockResult = StellarSdk.xdr.ScVal.scvVec([
+      StellarSdk.xdr.ScVal.scvBool(true),
+      StellarSdk.xdr.ScVal.scvVec([
+        StellarSdk.xdr.ScVal.scvMap([
+          new StellarSdk.xdr.ScMapEntry({
+            key: StellarSdk.xdr.ScVal.scvSymbol('vaccine_name'),
+            val: StellarSdk.xdr.ScVal.scvString('COVID-19')
+          }),
+          new StellarSdk.xdr.ScMapEntry({
+            key: StellarSdk.xdr.ScVal.scvSymbol('date_administered'),
+            val: StellarSdk.xdr.ScVal.scvString('2024-01-15')
+          })
+        ])
+      ]),
+    ]);
+
+    simulateContract.mockResolvedValueOnce(mockResult);
+
+    const res = await request(app)
+      .get(`/v1/verify/${VALID_WALLET}`)
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('verified', true);
+    expect(res.body).toHaveProperty('vaccinated', true);
+    expect(res.body).toHaveProperty('records');
+    expect(res.body.records).toHaveLength(1);
+    expect(res.body.records[0]).toHaveProperty('vaccine_name', 'COVID-19');
+    expect(res.body.records[0]).toHaveProperty('date_administered', '2024-01-15');
+  });
+
+  it('Test: valid unvaccinated wallet returns { verified: false, records: [] }', async () => {
+    // Mock simulation returning [false, []]
+    const mockResult = StellarSdk.xdr.ScVal.scvVec([
+      StellarSdk.xdr.ScVal.scvBool(false),
+      StellarSdk.xdr.ScVal.scvVec([]),
+    ]);
+
+    simulateContract.mockResolvedValueOnce(mockResult);
+
+    const res = await request(app)
+      .get(`/v1/verify/${UNVACCINATED_WALLET}`)
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('verified', false);
+    expect(res.body).toHaveProperty('vaccinated', false);
+    expect(res.body).toHaveProperty('records');
+    expect(res.body.records).toHaveLength(0);
+  });
+
+  it('Test: invalid wallet format returns 400', async () => {
+    const res = await request(app)
+      .get('/v1/verify/invalid-address-123')
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res.status).toBe(400);
+    expect(res.body).toHaveProperty('error');
+    expect(res.body.error).toContain('must be a valid Stellar public key');
+  });
+
+  it('Test: RPC timeout returns 503', async () => {
+    // Mock simulation throwing timeout error
+    simulateContract.mockRejectedValueOnce(new Error('Simulation failed: timeout'));
+
+    const res = await request(app)
+      .get(`/v1/verify/${VALID_WALLET}`)
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res.status).toBe(503);
+    expect(res.body).toHaveProperty('error');
+  });
+
+  it('Test: response is served from cache on second request within TTL', async () => {
+    const mockResult = StellarSdk.xdr.ScVal.scvVec([
+      StellarSdk.xdr.ScVal.scvBool(true),
+      StellarSdk.xdr.ScVal.scvVec([]),
+    ]);
+
+    simulateContract.mockResolvedValue(mockResult);
+
+    const cacheTestWallet = StellarSdk.Keypair.random().publicKey();
+
+    // First request
+    const res1 = await request(app)
+      .get(`/v1/verify/${cacheTestWallet}`)
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res1.status).toBe(200);
+    expect(simulateContract).toHaveBeenCalledTimes(1);
+
+    // Second request within TTL
+    const res2 = await request(app)
+      .get(`/v1/verify/${cacheTestWallet}`)
+      .set('Authorization', `Bearer ${validToken}`);
+
+    expect(res2.status).toBe(200);
+    // simulateContract should NOT have been called again
+    expect(simulateContract).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Description

Adds integration coverage for the public verify endpoint and implements minimal fixes required for the app to boot correctly.

Closes #340

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)

## Changes Made

* Added integration tests for verified, unverified, invalid wallet, timeout, and cache-hit scenarios
* Added lightweight TTL-based caching and RPC timeout handling to verify route
* Fixed duplicate `eventsRoutes` declaration and missing `securityHeaders` import blocking app boot

## Testing

* [ ] Unit tests pass
* [x] Integration tests pass
* [x] Manual testing completed

**Test Coverage:**

* `GET /v1/verify/:wallet`

## Checklist

* [x] My code follows the style guidelines of this project
* [x] I have performed a self-review of my own code
* [x] I have made corresponding changes to the documentation
* [x] I have added tests that prove my fix is effective or that my feature works

## Additional Notes

* JWT infrastructure was mocked locally inside the integration test file to avoid unrelated auth-system refactors
