### PR TITLE
feat(tests): add centralized fixture files for backend and frontend

### DIFF
--- a/backend/tests/fixtures/apiResponses.js
+++ b/backend/tests/fixtures/apiResponses.js
@@ -1,0 +1,91 @@
+// Centralized API response fixtures for backend tests.
+// Mirrors the shapes returned by the Express routes.
+
+const { PATIENT_WALLET, ISSUER_WALLET } = require('./wallets');
+
+module.exports = {
+  // Happy path: SEP-10 challenge response
+  SEP10_CHALLENGE: {
+    transaction: 'AAAAAgAAAABIQvkylb3/M+0wTwfqSo7VVV+xopwUcY+KJH31xvEGzgAAAGQAJZf9AAAAAwAAAAEAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAEAAAABAAAAAAAAAAA=',
+    nonce: 'test-nonce-123',
+  },
+
+  // Happy path: successful auth/verify response
+  AUTH_VERIFY_SUCCESS: {
+    token: 'eyJhbGciOiJIUzI1NiJ9.test.signature',
+    wallet: PATIENT_WALLET,
+    role: 'patient',
+  },
+
+  // Happy path: public verify endpoint — wallet is vaccinated
+  VERIFY_VACCINATED: {
+    wallet: PATIENT_WALLET,
+    vaccinated: true,
+    record_count: 2,
+  },
+
+  // Empty case: public verify endpoint — no records found
+  VERIFY_NOT_VACCINATED: {
+    wallet: PATIENT_WALLET,
+    vaccinated: false,
+    record_count: 0,
+  },
+
+  // Happy path: successful vaccination issue response
+  ISSUE_SUCCESS: {
+    success: true,
+    token_id: 'token-001',
+    tx_hash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+  },
+
+  // Happy path: issuer activity from analytics service
+  ANALYTICS_ISSUERS: {
+    issuers: [
+      {
+        address: ISSUER_WALLET,
+        count: 42,
+        last_active: '2024-01-15T10:00:00Z',
+      },
+    ],
+  },
+
+  // Happy path: vaccination rates from analytics service
+  ANALYTICS_RATES: {
+    rates: [
+      { vaccine_name: 'COVID-19', count: 120 },
+      { vaccine_name: 'Influenza', count: 80 },
+    ],
+  },
+
+  // Empty case: no anomalies detected
+  ANALYTICS_ANOMALIES_EMPTY: {
+    anomalies: [],
+  },
+
+  // Edge case: anomaly detected for an issuer
+  ANALYTICS_ANOMALIES_HIGH: {
+    anomalies: [
+      {
+        issuer: ISSUER_WALLET,
+        count: 200,
+        severity: 'high',
+        reason: 'Spike detected',
+      },
+    ],
+  },
+
+  // Edge case: generic 400 validation error shape
+  ERROR_VALIDATION: {
+    error: 'Validation failed',
+  },
+
+  // Edge case: 401 unauthorized shape
+  ERROR_UNAUTHORIZED: {
+    error: 'Missing authorization header',
+  },
+
+  // Edge case: 403 forbidden shape
+  ERROR_FORBIDDEN: {
+    error: 'Issuer role required',
+  },
+};

--- a/backend/tests/fixtures/jwts.js
+++ b/backend/tests/fixtures/jwts.js
@@ -1,0 +1,50 @@
+// Centralized JWT fixtures for backend tests.
+// Tokens are signed with the test secret used in tests/setup.js.
+
+const jwt = require('jsonwebtoken');
+const { PATIENT_WALLET, ISSUER_WALLET, ADMIN_WALLET } = require('./wallets');
+
+const SECRET = process.env.JWT_SECRET || 'test-jwt-secret';
+
+function sign(payload) {
+  return jwt.sign(payload, SECRET, { expiresIn: '1h' });
+}
+
+module.exports = {
+  // Happy path: valid patient JWT
+  PATIENT_TOKEN: sign({ sub: PATIENT_WALLET, wallet: PATIENT_WALLET, role: 'patient' }),
+
+  // Happy path: valid issuer JWT
+  ISSUER_TOKEN: sign({ sub: ISSUER_WALLET, wallet: ISSUER_WALLET, role: 'issuer' }),
+
+  // Happy path: valid admin JWT
+  ADMIN_TOKEN: sign({ sub: ADMIN_WALLET, wallet: ADMIN_WALLET, role: 'admin' }),
+
+  // Edge case: token signed with wrong secret
+  WRONG_SECRET_TOKEN: jwt.sign(
+    { sub: PATIENT_WALLET, wallet: PATIENT_WALLET, role: 'patient' },
+    'wrong-secret',
+    { expiresIn: '1h' }
+  ),
+
+  // Edge case: expired token
+  EXPIRED_TOKEN: jwt.sign(
+    { sub: PATIENT_WALLET, wallet: PATIENT_WALLET, role: 'patient' },
+    SECRET,
+    { expiresIn: '-1s' }
+  ),
+
+  // Edge case: token missing the wallet claim
+  TOKEN_MISSING_WALLET: jwt.sign(
+    { sub: PATIENT_WALLET, role: 'patient' },
+    SECRET,
+    { expiresIn: '1h' }
+  ),
+
+  // Edge case: token with an unrecognized role
+  TOKEN_INVALID_ROLE: jwt.sign(
+    { sub: PATIENT_WALLET, wallet: PATIENT_WALLET, role: 'superuser' },
+    SECRET,
+    { expiresIn: '1h' }
+  ),
+};

--- a/backend/tests/fixtures/vaccinationRecords.js
+++ b/backend/tests/fixtures/vaccinationRecords.js
@@ -1,0 +1,70 @@
+// Centralized vaccination record fixtures for backend tests.
+
+const { PATIENT_WALLET, ISSUER_WALLET } = require('./wallets');
+
+module.exports = {
+  // Happy path: a fully populated vaccination record
+  RECORD_COVID: {
+    token_id: 'token-001',
+    patient_address: PATIENT_WALLET,
+    vaccine_name: 'COVID-19',
+    date_administered: '2024-01-15',
+    issuer_address: ISSUER_WALLET,
+    lot_number: 'LOT-ABC123',
+    tx_hash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+  },
+
+  // Happy path: a second record for the same patient (different vaccine)
+  RECORD_FLU: {
+    token_id: 'token-002',
+    patient_address: PATIENT_WALLET,
+    vaccine_name: 'Influenza',
+    date_administered: '2023-10-01',
+    issuer_address: ISSUER_WALLET,
+    lot_number: 'LOT-FLU999',
+    tx_hash: 'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3',
+  },
+
+  // Happy path: valid issue request payload (POST /vaccination/issue body)
+  ISSUE_PAYLOAD: {
+    patient_address: PATIENT_WALLET,
+    vaccine_name: 'COVID-19',
+    date_administered: '2024-01-15',
+  },
+
+  // Edge case: issue payload with a future date
+  ISSUE_PAYLOAD_FUTURE_DATE: {
+    patient_address: PATIENT_WALLET,
+    vaccine_name: 'COVID-19',
+    date_administered: '2099-12-31',
+  },
+
+  // Edge case: issue payload missing required fields
+  ISSUE_PAYLOAD_MISSING_VACCINE: {
+    patient_address: PATIENT_WALLET,
+    date_administered: '2024-01-15',
+  },
+
+  // Empty case: no records found for a wallet
+  EMPTY_RECORDS_RESPONSE: {
+    data: [],
+    total: 0,
+    page: 1,
+    limit: 20,
+  },
+
+  // Happy path: paginated records response
+  PAGINATED_RECORDS_RESPONSE: {
+    data: [
+      {
+        token_id: 'token-001',
+        vaccine_name: 'COVID-19',
+        date_administered: '2024-01-15',
+        issuer_address: ISSUER_WALLET,
+      },
+    ],
+    total: 1,
+    page: 1,
+    limit: 20,
+  },
+};

--- a/backend/tests/fixtures/wallets.js
+++ b/backend/tests/fixtures/wallets.js
@@ -1,0 +1,25 @@
+// Centralized wallet address fixtures for backend tests.
+// All addresses are valid 56-char Stellar public keys (G...).
+
+module.exports = {
+  // Happy path: a standard patient wallet
+  PATIENT_WALLET: 'GA3AUY2XRF6S7R73ABSLJMKG4R2NQGRUFPEJUGCANMBAAXI4MTBS6AQU',
+
+  // Happy path: an authorized issuer wallet
+  ISSUER_WALLET: 'GBXGQJWVLWOYHFLEWA4HDYEGRMTBPBMOU2ISCESQ3GIJBKBEDNZXMRQO',
+
+  // Happy path: an admin wallet
+  ADMIN_WALLET: 'GDQJUTQYK2MQX2ZJARTDFPCOHAKIEW2GDCJJSXMFQWNZXWBTVHSWKHEF',
+
+  // Edge case: a second patient wallet (for multi-wallet tests)
+  PATIENT_WALLET_2: 'GCEZWKCA5VLDNRLN3RPRJMRZOX3Z6G5CHCGZQE6CJNQZP7SOQKQNBHQ',
+
+  // Edge case: invalid format (too short)
+  INVALID_WALLET_SHORT: 'GABC123',
+
+  // Edge case: invalid format (wrong prefix)
+  INVALID_WALLET_PREFIX: 'XABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ12345678901234',
+
+  // Edge case: empty string
+  EMPTY_WALLET: '',
+};

--- a/frontend/src/__tests__/fixtures/apiResponses.js
+++ b/frontend/src/__tests__/fixtures/apiResponses.js
@@ -1,0 +1,62 @@
+// Centralized API response fixtures for frontend tests.
+// Mirrors the shapes returned by the backend and analytics service.
+
+import { PATIENT_WALLET, ISSUER_WALLET } from './wallets';
+import { RECORDS_LIST } from './vaccinationRecords';
+
+// Happy path: public verify — wallet is vaccinated
+export const VERIFY_VACCINATED = {
+  wallet: PATIENT_WALLET,
+  vaccinated: true,
+  record_count: 2,
+};
+
+// Empty case: public verify — no records found
+export const VERIFY_NOT_VACCINATED = {
+  wallet: PATIENT_WALLET,
+  vaccinated: false,
+  record_count: 0,
+};
+
+// Happy path: vaccination rates from analytics service
+export const ANALYTICS_RATES = {
+  rates: [
+    { vaccine_name: 'COVID-19', count: 120 },
+    { vaccine_name: 'Influenza', count: 80 },
+  ],
+};
+
+// Happy path: issuer activity from analytics service
+export const ANALYTICS_ISSUERS = {
+  issuers: [
+    {
+      address: ISSUER_WALLET,
+      count: 42,
+      last_active: '2024-01-15T10:00:00Z',
+    },
+  ],
+};
+
+// Empty case: no anomalies detected
+export const ANALYTICS_ANOMALIES_EMPTY = {
+  anomalies: [],
+};
+
+// Edge case: high-severity anomaly detected
+export const ANALYTICS_ANOMALIES_HIGH = {
+  anomalies: [
+    {
+      issuer: ISSUER_WALLET,
+      count: 200,
+      severity: 'high',
+      reason: 'Spike detected',
+    },
+  ],
+};
+
+// Happy path: successful vaccination issue response
+export const ISSUE_SUCCESS = {
+  success: true,
+  token_id: 'token-001',
+  tx_hash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+};

--- a/frontend/src/__tests__/fixtures/jwts.js
+++ b/frontend/src/__tests__/fixtures/jwts.js
@@ -1,0 +1,15 @@
+// Centralized JWT fixtures for frontend tests.
+// These are static opaque strings — frontend only passes them in headers,
+// it never decodes them, so realistic-looking values are sufficient.
+
+// Happy path: a valid patient JWT
+export const PATIENT_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.patient.signature';
+
+// Happy path: a valid issuer JWT
+export const ISSUER_TOKEN = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.issuer.signature';
+
+// Edge case: an expired / invalid token string
+export const INVALID_TOKEN = 'invalid.token.value';
+
+// Edge case: empty string (no token)
+export const EMPTY_TOKEN = '';

--- a/frontend/src/__tests__/fixtures/vaccinationRecords.js
+++ b/frontend/src/__tests__/fixtures/vaccinationRecords.js
@@ -1,0 +1,65 @@
+// Centralized vaccination record fixtures for frontend tests.
+
+import { PATIENT_WALLET, ISSUER_WALLET } from './wallets';
+
+// Happy path: a single fully populated record
+export const RECORD_COVID = {
+  token_id: 'token-001',
+  vaccine_name: 'COVID-19',
+  date_administered: '2024-01-15',
+  issuer: ISSUER_WALLET,
+  tx_hash: 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2',
+};
+
+// Happy path: a second record (different vaccine)
+export const RECORD_FLU = {
+  token_id: 'token-002',
+  vaccine_name: 'Influenza',
+  date_administered: '2023-10-01',
+  issuer: ISSUER_WALLET,
+  tx_hash: 'b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3',
+};
+
+// Edge case: record with dose series info
+export const RECORD_WITH_DOSE = {
+  ...RECORD_COVID,
+  token_id: 'token-003',
+  dose_number: 2,
+  dose_series: 3,
+};
+
+// Edge case: record without a transaction hash
+export const RECORD_NO_TX_HASH = {
+  ...RECORD_COVID,
+  token_id: 'token-004',
+  tx_hash: null,
+};
+
+// Empty case: no records for a wallet
+export const EMPTY_RECORDS = [];
+
+// Happy path: list of two records
+export const RECORDS_LIST = [RECORD_COVID, RECORD_FLU];
+
+// Happy path: paginated API response with records
+export const PAGINATED_RESPONSE = {
+  data: RECORDS_LIST,
+  total: 2,
+  page: 1,
+  limit: 20,
+};
+
+// Empty case: paginated API response with no records
+export const EMPTY_PAGINATED_RESPONSE = {
+  data: [],
+  total: 0,
+  page: 1,
+  limit: 20,
+};
+
+// Happy path: valid mint form payload
+export const MINT_PAYLOAD = {
+  patient_address: PATIENT_WALLET,
+  vaccine_name: 'COVID-19',
+  date_administered: '2024-01-15',
+};

--- a/frontend/src/__tests__/fixtures/wallets.js
+++ b/frontend/src/__tests__/fixtures/wallets.js
@@ -1,0 +1,10 @@
+// Centralized wallet address fixtures for frontend tests.
+
+export const PATIENT_WALLET = 'GA3AUY2XRF6S7R73ABSLJMKG4R2NQGRUFPEJUGCANMBAAXI4MTBS6AQU';
+export const ISSUER_WALLET  = 'GBXGQJWVLWOYHFLEWA4HDYEGRMTBPBMOU2ISCESQ3GIJBKBEDNZXMRQO';
+
+// Edge case: invalid Stellar address (too short)
+export const INVALID_WALLET = 'GABC123';
+
+// Edge case: empty string
+export const EMPTY_WALLET = '';


### PR DESCRIPTION
Closes #344

---

Description:

## What
Adds centralized fixture files for both backend and frontend tests, replacing scattered inline mock data with a single source of truth.

## Why
Test files across the codebase defined the same mock data (wallet addresses, vaccination records, JWTs, API responses) inline and inconsistently. This made tests 
brittle and hard to maintain — a change to a data shape required hunting down every test file.

## Changes
- backend/tests/fixtures/wallets.js — valid/invalid Stellar addresses
- backend/tests/fixtures/vaccinationRecords.js — record objects and issue payloads
- backend/tests/fixtures/jwts.js — signed tokens for patient, issuer, admin, and edge cases
- backend/tests/fixtures/apiResponses.js — shaped responses for auth, vaccination, verify, and analytics endpoints
- frontend/src/__tests__/fixtures/wallets.js — same wallet constants in ESM
- frontend/src/__tests__/fixtures/vaccinationRecords.js — record objects, paginated responses, mint payload
- frontend/src/__tests__/fixtures/jwts.js — opaque token strings for frontend header usage
- frontend/src/__tests__/fixtures/apiResponses.js — verify, analytics, and issue response shapes

Each fixture covers happy path, empty, and edge case scenarios, with every export documented by an inline comment.

## Testing
No existing tests were modified. Fixtures are ready to be imported by existing and future tests.