### PR TITLE
ci: add Gitleaks secret scanning job to CI pipeline with job summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,52 @@ jobs:
   all-tests:
     name: All tests passed
     runs-on: ubuntu-latest
-    needs: [contract, backend, frontend, python]
+    needs: [contract, backend, frontend, python, gitleaks]
     steps:
       - run: echo "All test jobs passed."
+
+  gitleaks:
+    name: Secret scanning (Gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Gitleaks
+        id: gitleaks
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Write job summary
+        if: always()
+        run: |
+          if [ "${{ steps.gitleaks.outcome }}" = "success" ]; then
+            echo "## ✅ Gitleaks Secret Scan" >> $GITHUB_STEP_SUMMARY
+            echo "No secrets detected." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "## ❌ Gitleaks Secret Scan — Secrets Detected" >> $GITHUB_STEP_SUMMARY
+            echo "Gitleaks found potential secrets in this commit. Review the report artifact." >> $GITHUB_STEP_SUMMARY
+            if [ -f gitleaks-report.json ]; then
+              echo '```json' >> $GITHUB_STEP_SUMMARY
+              cat gitleaks-report.json >> $GITHUB_STEP_SUMMARY
+              echo '```' >> $GITHUB_STEP_SUMMARY
+            fi
+          fi
+
+      - name: Upload Gitleaks report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: gitleaks-report
+          path: gitleaks-report.json
+          retention-days: 30
+
+      - name: Fail if secrets detected
+        if: steps.gitleaks.outcome == 'failure'
+        run: exit 1
 
   docker:
     name: Docker build validation


### PR DESCRIPTION
- Add gitleaks job to ci.yml that runs on every PR and push to main
- Fetches full git history (fetch-depth: 0) for complete scan coverage
- CI fails if any secrets are detected
- Writes pass/fail summary to GitHub Actions job summary
- Uploads gitleaks-report.json artifact on failure for review
- .gitleaks.toml already committed with allowlist rules for false positives
- Add gitleaks to all-tests gate so secret scan must pass before merge

Closes #333
Closes #334

## Description

Please include a summary of the changes and related context.

Closes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Changes Made

- 
- 
- 

## Testing

Please describe the tests you ran and how to reproduce them:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

**Test Coverage:**
- 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests passed locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

If your changes include UI modifications, please add screenshots here.

## Additional Notes

Any additional information that reviewers should know.
