### PR TITLE
chore: set dependabot schedule to weekly for npm and pip

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -3,17 +3,17 @@ updates:
   - package-ecosystem: "npm"
     directory: "/backend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "pip"
     directory: "/python-service"
     schedule:
-      interval: "daily"
+      interval: "weekly"
 
   - package-ecosystem: "cargo"
     directory: "/contracts"


### PR DESCRIPTION
closes #326 

# Update Dependabot schedule to weekly

This change modifies the Dependabot configuration so that npm (backend & frontend) and pip dependencies are checked **weekly** instead of daily.

### Why
- Reduces unnecessary CI runs and API traffic.
- Aligns with the repository’s maintenance cadence.

### What changed
- `dependabot.yml` – `interval` values updated from `daily` to `weekly` for:
  - `/backend` (npm)
  - `/frontend` (npm)
  - `/python-service` (pip)

All other configuration remains untouched. The CI workflow will now trigger Dependabot PRs once a week, while still handling daily scans for cargo updates.
