### PR TITLE
Add toast notification system with context provider and icons

### DIFF
--- a/frontend/src/hooks/useToast.jsx
+++ b/frontend/src/hooks/useToast.jsx
@@ -16,7 +16,10 @@ export function ToastProvider({ children }) {
   return (
     <ToastContext.Provider value={toast}>
       {children}
-      <ToastList toasts={toasts} onDismiss={(id) => setToasts((t) => t.filter((x) => x.id !== id))} />
+      <ToastList
+        toasts={toasts}
+        onDismiss={(id) => setToasts((t) => t.filter((x) => x.id !== id))}
+      />
     </ToastContext.Provider>
   );
 }
@@ -24,35 +27,73 @@ export function ToastProvider({ children }) {
 function ToastList({ toasts, onDismiss }) {
   if (!toasts.length) return null;
   return (
-    <div style={{ position: 'fixed', bottom: '1.5rem', right: '1.5rem', display: 'flex', flexDirection: 'column', gap: '0.5rem', zIndex: 9999 }}>
+    <div
+      aria-live="polite"
+      style={{
+        position: 'fixed',
+        top: '1.5rem',
+        right: '1.5rem',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '0.5rem',
+        zIndex: 9999,
+        alignItems: 'flex-end',
+      }}
+    >
       {toasts.map((t) => (
         <div
           key={t.id}
           role="alert"
           style={{
-            padding: '0.75rem 1rem',
+            padding: '0.6rem 0.75rem',
             borderRadius: 8,
             color: '#fff',
             fontSize: '0.9rem',
-            maxWidth: 320,
+            maxWidth: 360,
             display: 'flex',
-            justifyContent: 'space-between',
             alignItems: 'center',
             gap: '0.75rem',
+            boxShadow: '0 6px 18px rgba(0,0,0,0.12)',
             background: t.type === 'success' ? '#16a34a' : t.type === 'error' ? '#dc2626' : '#0ea5e9',
           }}
         >
-          <span>{t.message}</span>
+          <Icon type={t.type} />
+          <span style={{ flex: 1 }}>{t.message}</span>
           <button
             onClick={() => onDismiss(t.id)}
             aria-label="Dismiss"
-            style={{ background: 'none', border: 'none', color: '#fff', cursor: 'pointer', fontSize: '1rem', lineHeight: 1 }}
+            style={{ background: 'transparent', border: 'none', color: '#fff', cursor: 'pointer', fontSize: '1.1rem', lineHeight: 1 }}
           >
             ×
           </button>
         </div>
       ))}
     </div>
+  );
+}
+
+function Icon({ type }) {
+  const common = { width: 18, height: 18, fill: 'none', stroke: 'white', strokeWidth: 2 };
+  if (type === 'success') {
+    return (
+      <svg viewBox="0 0 24 24" style={{ flex: '0 0 auto' }} {...common}>
+        <path d="M20 6L9 17l-5-5" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    );
+  }
+  if (type === 'error') {
+    return (
+      <svg viewBox="0 0 24 24" style={{ flex: '0 0 auto' }} {...common}>
+        <path d="M18 6L6 18M6 6l12 12" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
+    );
+  }
+  return (
+    <svg viewBox="0 0 24 24" style={{ flex: '0 0 auto' }} {...common}>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 8v4" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx="12" cy="17" r="1" />
+    </svg>
   );
 }
 

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,6 +3,7 @@ import ReactDOM from 'react-dom/client';
 import { BrowserRouter } from 'react-router-dom';
 import './i18n';
 import App from './App';
+import { ToastProvider } from './hooks/useToast';
 import ErrorBoundary from './components/ErrorBoundary';
 import './index.css';
 
@@ -18,7 +19,9 @@ enableMocking().then(() => {
     <React.StrictMode>
       <BrowserRouter>
         <ErrorBoundary>
-          <App />
+          <ToastProvider>
+            <App />
+          </ToastProvider>
         </ErrorBoundary>
       </BrowserRouter>
     </React.StrictMode>


### PR DESCRIPTION
Closes #245 

Created 4 todos

Planned steps: 1) Inspect frontend to find toast hook and app entry. 2) Enhance the toast UI (icons, top-right position, styling). 3) Wrap app with provider so `useToast()` works everywhere. Now done.

- **What I changed:**  
  - **Files:** useToast.jsx, main.jsx  
  - **Summary:** Added icons and improved styling to the toast list, moved toasts to the top-right, retained 4s auto-dismiss and manual dismiss button, and wrapped the app with `ToastProvider` so `useToast()` works app-wide.

- **Acceptance criteria satisfied:**  
  - **Position:** Top-right fixed position.  
  - **Variants:** `success`, `error`, `info` each have distinct colors and SVG icons.  
  - **Auto-dismiss:** Toasts auto-dismiss after 4 seconds.  
  - **Manual dismiss:** Each toast has a dismiss (`×`) button.  
  - **Stacking:** Multiple toasts stack with spacing and box-shadow (no overlap).

- **How to try locally:**  
  Run in the frontend folder:
  ```bash
  cd frontend
  npm install
  npm run dev
  ```

Made changes.