### PR TITLE
feat: add dark mode toggle with localStorage persistence

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,7 +18,7 @@ export default function App() {
   return (
     <AuthProvider>
       <DemoBanner/>
-      <NavBar />
+      <NavBar dark={dark} onToggleDark={() => setDark((d) => !d)} />
       <FreighterBanner />
       <Routes>
         <Route path="/" element={<Landing />} />

--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Link, useLocation } from 'react-router-dom';
+import DarkModeToggle from './DarkModeToggle';
 
 const NAV_LINKS = [
   { to: '/', label: 'Home' },
@@ -11,7 +12,7 @@ const NAV_LINKS = [
   { to: '/analytics', label: 'Analytics' },
 ];
 
-export default function NavBar() {
+export default function NavBar({ dark, onToggleDark }) {
   const { pathname } = useLocation();
   const [open, setOpen] = useState(false);
 
@@ -29,8 +30,8 @@ export default function NavBar() {
   useEffect(() => { close(); }, [pathname, close]);
 
   return (
-    <nav aria-label="Main navigation" style={{ padding: '1rem 2rem', background: '#1e293b', display: 'flex', flexWrap: 'wrap', gap: '1.5rem', alignItems: 'center', position: 'relative' }}>
-      <strong style={{ color: '#38bdf8', fontSize: '1.2rem', flex: 1 }}>💉 VacciChain</strong>
+    <nav aria-label="Main navigation" style={{ padding: '1rem 2rem', background: 'var(--nav-bg)', display: 'flex', flexWrap: 'wrap', gap: '1.5rem', alignItems: 'center', position: 'relative' }}>
+      <strong style={{ color: 'var(--accent)', fontSize: '1.2rem', flex: 1 }}>💉 VacciChain</strong>
 
       {/* Hamburger button — visible only below 640px */}
       <button
@@ -68,6 +69,7 @@ export default function NavBar() {
             {label}
           </Link>
         ))}
+        <DarkModeToggle dark={dark} onToggle={onToggleDark} />
       </div>
 
       <style>{`

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,8 +1,42 @@
+:root {
+  --bg: #ffffff;
+  --text: #0f172a;
+  --text-muted: #64748b;
+  --accent: #0284c7;
+  --btn-primary: #0284c7;
+  --input-bg: #f1f5f9;
+  --border: #cbd5e1;
+  --nav-bg: #1e293b;
+  --nav-text: #cbd5e1;
+  --role-patient-bg: #e0f2fe;
+  --role-patient-text: #0284c7;
+  --role-patient-border: #7dd3fc;
+  --role-issuer-bg: #dcfce7;
+  --role-issuer-text: #16a34a;
+}
+
+.dark {
+  --bg: #0f172a;
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --accent: #38bdf8;
+  --btn-primary: #0ea5e9;
+  --input-bg: #1e293b;
+  --border: #334155;
+  --nav-bg: #1e293b;
+  --nav-text: #cbd5e1;
+  --role-patient-bg: #0c2a4a;
+  --role-patient-text: #38bdf8;
+  --role-patient-border: #0ea5e9;
+  --role-issuer-bg: #052e16;
+  --role-issuer-text: #4ade80;
+}
+
 * { box-sizing: border-box; margin: 0; padding: 0; }
-body { font-family: system-ui, sans-serif; background: #0f172a; color: #e2e8f0; min-height: 100vh; }
-a { color: #38bdf8; text-decoration: none; }
+body { font-family: system-ui, sans-serif; background: var(--bg); color: var(--text); min-height: 100vh; }
+a { color: var(--accent); text-decoration: none; }
 a:hover { text-decoration: underline; }
 button { cursor: pointer; }
-:focus-visible { outline: 2px solid #38bdf8; outline-offset: 3px; }
-nav a { color: #cbd5e1; }
-nav a[aria-current="page"] { color: #38bdf8; font-weight: 600; }
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+nav a { color: var(--nav-text); }
+nav a[aria-current="page"] { color: var(--accent); font-weight: 600; }


### PR DESCRIPTION
Closes #244 
- Define CSS variables in index.css for light (:root) and dark (.dark) themes covering --bg, --text, --text-muted, --accent, --btn-primary, --input-bg, --border, --nav-bg, --nav-text, and --role-* variables
- Wire DarkModeToggle into NavBar (accepts dark/onToggleDark props)
- Pass dark state and toggle handler from App.jsx to NavBar
- Default follows prefers-color-scheme; preference persisted in localStorage
- Toggle button has accessible aria-label (Switch to dark/light mode)

## Description

Please include a summary of the changes and related context.

Closes #(issue number)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Changes Made

- 
- 
- 

## Testing

Please describe the tests you ran and how to reproduce them:

- [ ] Unit tests pass
- [ ] Integration tests pass
- [ ] Manual testing completed

**Test Coverage:**
- 

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests passed locally with my changes
- [ ] Any dependent changes have been merged and published
- [ ] If this PR adds a new directory or key file, I have updated `docs/folder-structure.md`.

## Screenshots (if applicable)

If your changes include UI modifications, please add screenshots here.

## Additional Notes

Any additional information that reviewers should know.
