### PR TITLE
feat: vaccination issue/fetch integration tests with mocked Soroban RPC

### DIFF
--- a/backend/src/routes/vaccination.js
+++ b/backend/src/routes/vaccination.js
@@ -5,7 +5,7 @@ const authMiddleware = require('../middleware/auth');
 const issuerMiddleware = require('../middleware/issuer');
 const { validateStellarPublicKey } = require('../middleware/wallet');
 const { invokeContract, simulateContract, mintVaccination, sendRpcTimeout, SorobanTimeoutError } = require('../stellar/soroban');
-const { resolveContractErrorMessage } = require('../stellar/contractErrors');
+const { resolveContractErrorMessage, mapContractError } = require('../stellar/contractErrors');
 const { audit } = require('../middleware/auditLog');
 const validate = require('../middleware/validate');
 const { hasConsented } = require('../indexer/db');
@@ -134,6 +134,10 @@ router.post(
       result: 'failure',
       meta: { error: errorMessage },
     });
+    const mapped = mapContractError(err);
+    if (mapped?.name === 'DuplicateRecord') {
+      return res.status(409).json({ error: errorMessage });
+    }
     res.status(500).json({ error: errorMessage });
   }
 });

--- a/backend/tests/vaccination-issue-fetch.test.js
+++ b/backend/tests/vaccination-issue-fetch.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const request = require('supertest');
+const StellarSdk = require('@stellar/stellar-sdk');
+
+// Must be mocked before app is loaded
+jest.mock('../src/jwtKeys', () => ({
+  getVerificationKeys: () => [{ kid: '1', secret: 'test-jwt-secret' }],
+  getSigningKey: () => ({ kid: '1', secret: 'test-jwt-secret' }),
+  rotateKey: jest.fn(),
+  reloadFromEnv: jest.fn(),
+}));
+
+const app = require('../src/app');
+const jwtFactory = require('./factories/jwt');
+const { PATIENT_WALLET, ISSUER_WALLET } = require('./fixtures/wallets');
+
+// Mock Soroban RPC — controlled per-test via mockResolvedValue / mockRejectedValue
+jest.mock('../src/stellar/soroban', () => {
+  const sdk = require('@stellar/stellar-sdk');
+  const emptyRecords = sdk.xdr.ScVal.scvVec([
+    sdk.xdr.ScVal.scvBool(true),
+    sdk.xdr.ScVal.scvVec([]),
+  ]);
+  return {
+    mintVaccination: jest.fn().mockResolvedValue({ tokenId: 'tok_1', hash: 'abc123', ledger: 1000 }),
+    simulateContract: jest.fn().mockResolvedValue(emptyRecords),
+    sendRpcTimeout: jest.fn(),
+    SorobanTimeoutError: class SorobanTimeoutError extends Error {},
+  };
+});
+
+// Mock issuer on-chain check
+jest.mock('../src/stellar/issuerCache', () => ({
+  isAuthorizedIssuer: jest.fn().mockResolvedValue(true),
+}));
+
+// Mock patient consent
+jest.mock('../src/indexer/db', () => ({
+  hasConsented: jest.fn().mockReturnValue(true),
+  initDb: jest.fn().mockResolvedValue(undefined),
+  getDb: jest.fn(),
+}));
+
+const { mintVaccination, simulateContract } = require('../src/stellar/soroban');
+
+const VALID_BODY = {
+  patient_address: PATIENT_WALLET,
+  vaccine_name: 'COVID-19',
+  date_administered: '2024-01-15',
+};
+
+let issuerToken;
+let patientToken;
+
+beforeAll(() => {
+  issuerToken = jwtFactory({ publicKey: ISSUER_WALLET, role: 'issuer' });
+  patientToken = jwtFactory({ publicKey: PATIENT_WALLET, role: 'patient' });
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mintVaccination.mockResolvedValue({ tokenId: 'tok_1', hash: 'abc123', ledger: 1000 });
+  const sdk = require('@stellar/stellar-sdk');
+  simulateContract.mockResolvedValue(
+    sdk.xdr.ScVal.scvVec([sdk.xdr.ScVal.scvBool(true), sdk.xdr.ScVal.scvVec([])])
+  );
+});
+
+describe('POST /v1/vaccination/issue', () => {
+  it('returns 200 with issuer JWT and valid body', async () => {
+    const res = await request(app)
+      .post('/v1/vaccination/issue')
+      .set('Authorization', `Bearer ${issuerToken}`)
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ success: true, tokenId: 'tok_1', transactionHash: 'abc123' });
+  });
+
+  it('returns 403 with patient JWT', async () => {
+    const res = await request(app)
+      .post('/v1/vaccination/issue')
+      .set('Authorization', `Bearer ${patientToken}`)
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 409 when contract returns DuplicateRecord error', async () => {
+    mintVaccination.mockRejectedValue(new Error('Error(Contract, #6)'));
+
+    const res = await request(app)
+      .post('/v1/vaccination/issue')
+      .set('Authorization', `Bearer ${issuerToken}`)
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/identical|duplicate/i);
+  });
+});
+
+describe('GET /v1/vaccination/:wallet', () => {
+  it('returns records array with valid JWT', async () => {
+    const res = await request(app)
+      .get(`/v1/vaccination/${PATIENT_WALLET}`)
+      .set('Authorization', `Bearer ${patientToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('data');
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('returns 400 for invalid wallet format', async () => {
+    const res = await request(app)
+      .get('/v1/vaccination/not-a-valid-wallet')
+      .set('Authorization', `Bearer ${patientToken}`);
+
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
## Summary

Adds integration tests for the vaccination issue and fetch endpoints with mocked Soroban RPC calls, and adds 409 handling for duplicate vaccination records.

## Changes

**`backend/src/routes/vaccination.js`**
- Import `mapContractError` alongside the existing `resolveContractErrorMessage`
- Return 409 when the contract error is `DuplicateRecord` (code 6) instead of 500

**`backend/tests/vaccination-issue-fetch.test.js`** (new)
- Mocks: `soroban` (mintVaccination, simulateContract), `issuerCache` (isAuthorizedIssuer), `indexer/db` (hasConsented), `jwtKeys` (getVerificationKeys)
- `POST /v1/vaccination/issue` with issuer JWT and valid body → 200
- `POST /v1/vaccination/issue` with patient JWT → 403
- `POST /v1/vaccination/issue` with duplicate record → 409
- `GET /v1/vaccination/:wallet` with valid JWT → records array
- `GET /v1/vaccination/:wallet` with invalid wallet format → 400

## Testing

All 5 new tests pass:
```
PASS tests/vaccination-issue-fetch.test.js
  POST /v1/vaccination/issue
    ✓ returns 200 with issuer JWT and valid body
    ✓ returns 403 with patient JWT
    ✓ returns 409 when contract returns DuplicateRecord error
  GET /v1/vaccination/:wallet
    ✓ returns records array with valid JWT
    ✓ returns 400 for invalid wallet format
```

Closes #339