### PR TITLE
feat: highlight active navigation item in navbar

### DIFF
--- a/frontend/src/components/NavBar.jsx
+++ b/frontend/src/components/NavBar.jsx
@@ -226,16 +226,25 @@ export default function NavBar({ dark, onToggleDark }) {
         style={{ display: 'flex', gap: '1.5rem', alignItems: 'center', flexWrap: 'wrap' }}
         ref={linksRef}
       >
-        {NAV_LINKS.map(({ to, label }) => (
-          <Link
-            key={to}
-            to={to}
-            aria-current={pathname === to ? 'page' : undefined}
-            onClick={close}
-          >
-            {label}
-          </Link>
-        ))}
+        {NAV_LINKS.map(({ to, label }) => {
+          const isActive = pathname === to;
+          return (
+            <Link
+              key={to}
+              to={to}
+              aria-current={isActive ? 'page' : undefined}
+              onClick={close}
+              style={isActive ? {
+                color: 'var(--accent)',
+                borderBottom: '2px solid var(--accent)',
+                paddingBottom: '2px',
+                fontWeight: 600,
+              } : undefined}
+            >
+              {label}
+            </Link>
+          );
+        })}
         <DarkModeToggle dark={dark} onToggle={onToggleDark} />
         <WalletIndicator />
       </div>


### PR DESCRIPTION
## Summary

Resolves #234

The navbar now visually highlights the currently active route so users always know which page they're on.

## Changes

- **NavBar.jsx** – active link receives accent color, bold font weight, and a bottom border underline, driven by `useLocation` pathname comparison

## Acceptance Criteria

- [x] Active nav item has a distinct visual style (accent color + underline)
- [x] Active state updates immediately on route change (driven by `useLocation`)
- [x] Active state is driven by the current route, not manual state
- [x] Active item has `aria-current="page"` attribute (already present, preserved)
- [x] Style uses `var(--accent)` CSS variable — consistent in both light and dark modes