### PR TITLE
feat: apply API-Version header globally via middleware

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,9 @@ JWT_PREVIOUS_KEYS=
 # TCP port for the Express backend (default: 4000)
 PORT=4000
 
+# API version header value returned in all responses (default: 1)
+API_VERSION=1
+
 # Winston log level for the backend (default: info)
 # Allowed values: error | warn | info | http | debug
 LOG_LEVEL=info

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -44,6 +44,8 @@ app.use(cors({
   optionsSuccessStatus: 204,
 }));
 app.use(securityHeaders);
+// Apply API version header globally to all responses
+app.use(apiVersion);
 app.use(express.json({ limit: config.BODY_LIMIT }));
 app.use(requestId);
 // Sanitize all string inputs at the API boundary (strips HTML tags, control chars, null bytes)
@@ -65,7 +67,6 @@ app.use((req, res, next) => {
 
 // v1 routes — all API endpoints are versioned under /v1/
 const v1 = express.Router();
-v1.use(apiVersion);
 v1.use('/auth', authRoutes);
 v1.use('/vaccination', vaccinationRoutes);
 v1.use('/verify', verifyRoutes);

--- a/backend/src/config.js
+++ b/backend/src/config.js
@@ -46,6 +46,9 @@ const schema = z.object({
   // Indexer
   EVENT_POLL_INTERVAL_MS: z.coerce.number().int().positive().default(15000),
   DATABASE_PATH: z.string().default('/data/vaccichain.db'),
+
+  // API versioning
+  API_VERSION: z.string().default('1'),
 });
 
 function validateEnv(env) {

--- a/backend/src/middleware/apiVersion.js
+++ b/backend/src/middleware/apiVersion.js
@@ -1,13 +1,14 @@
 /**
  * API versioning middleware.
- * Adds API-Version header to all responses.
+ * Adds API-Version header to all responses globally.
  * When a version is sunset, adds Deprecation header.
  */
-const CURRENT_VERSION = '1';
+const config = require('../config');
+
 const SUNSET_VERSIONS = {}; // e.g. { '0': 'Sat, 01 Jan 2025 00:00:00 GMT' }
 
 function apiVersion(req, res, next) {
-  res.setHeader('API-Version', CURRENT_VERSION);
+  res.setHeader('API-Version', config.API_VERSION);
   const requestedVersion = req.params.version;
   if (requestedVersion && SUNSET_VERSIONS[requestedVersion]) {
     res.setHeader('Deprecation', 'true');

--- a/backend/tests/api-version-header.test.js
+++ b/backend/tests/api-version-header.test.js
@@ -1,0 +1,99 @@
+const request = require('supertest');
+const app = require('../src/app');
+
+describe('API-Version Header', () => {
+  describe('Successful responses (2xx)', () => {
+    it('should include API-Version header on health check', async () => {
+      const res = await request(app)
+        .get('/health')
+        .expect(200);
+
+      expect(res.headers['api-version']).toBe('1');
+    });
+  });
+
+  describe('Redirect responses (3xx)', () => {
+    it('should include API-Version header on unversioned redirects', async () => {
+      const res = await request(app)
+        .post('/auth/sep10')
+        .send({ public_key: 'GBADTESTKEY' })
+        .expect(308);
+
+      expect(res.headers['api-version']).toBe('1');
+      expect(res.headers.location).toBe('/v1/auth/sep10');
+    });
+
+    it('should include API-Version header on all redirect types', async () => {
+      const res = await request(app)
+        .get('/verify/GBADTESTKEY')
+        .expect(308);
+
+      expect(res.headers['api-version']).toBe('1');
+    });
+  });
+
+  describe('Client error responses (4xx)', () => {
+    it('should include API-Version header on 404 errors', async () => {
+      const res = await request(app)
+        .get('/nonexistent-route')
+        .expect(404);
+
+      expect(res.headers['api-version']).toBe('1');
+    });
+
+    it('should include API-Version header on validation errors', async () => {
+      const res = await request(app)
+        .post('/v1/auth/sep10')
+        .send({}) // Missing required public_key
+        .expect(400);
+
+      expect(res.headers['api-version']).toBe('1');
+    });
+  });
+
+  describe('Server error responses (5xx)', () => {
+    it('should include API-Version header on error handler responses', async () => {
+      // This test verifies that the error handler preserves the API-Version header
+      // We'll trigger an error by sending invalid data to an endpoint
+      const res = await request(app)
+        .post('/v1/auth/sep10')
+        .send({ public_key: 'INVALID_KEY_FORMAT' })
+        .expect(400);
+
+      expect(res.headers['api-version']).toBe('1');
+    });
+  });
+
+  describe('All route types', () => {
+    it('should include API-Version header on versioned routes', async () => {
+      const res = await request(app)
+        .post('/v1/auth/sep10')
+        .send({ public_key: 'GBADTESTKEY' });
+
+      expect(res.headers['api-version']).toBe('1');
+    });
+
+    it('should include API-Version header on unversioned routes', async () => {
+      const res = await request(app)
+        .post('/auth/sep10')
+        .send({ public_key: 'GBADTESTKEY' })
+        .expect(308);
+
+      expect(res.headers['api-version']).toBe('1');
+    });
+
+    it('should include API-Version header on health endpoint', async () => {
+      const res = await request(app)
+        .get('/health');
+
+      expect(res.headers['api-version']).toBe('1');
+    });
+  });
+
+  describe('Configuration', () => {
+    it('should use API_VERSION from config', () => {
+      const config = require('../src/config');
+      expect(config.API_VERSION).toBe('1');
+    });
+  });
+});

--- a/backend/tests/unversioned-redirect.test.js
+++ b/backend/tests/unversioned-redirect.test.js
@@ -11,6 +11,7 @@ describe('Unversioned Path Redirects', () => {
 
       expect(res.headers.location).toBe('/v1/auth/sep10');
       expect(res.headers.deprecation).toBe('true');
+      expect(res.headers['api-version']).toBe('1');
     });
   });
 
@@ -103,6 +104,7 @@ describe('Unversioned Path Redirects', () => {
 
       expect(res.headers.location).toBe('/v1/admin/issuers');
       expect(res.headers.deprecation).toBe('true');
+      expect(res.headers['api-version']).toBe('1');
     });
 
     it('should redirect /patient paths', async () => {
@@ -113,6 +115,7 @@ describe('Unversioned Path Redirects', () => {
 
       expect(res.headers.location).toBe('/v1/patient/register');
       expect(res.headers.deprecation).toBe('true');
+      expect(res.headers['api-version']).toBe('1');
     });
 
     it('should redirect /events paths', async () => {
@@ -122,6 +125,7 @@ describe('Unversioned Path Redirects', () => {
 
       expect(res.headers.location).toBe('/v1/events');
       expect(res.headers.deprecation).toBe('true');
+      expect(res.headers['api-version']).toBe('1');
     });
   });
 });


### PR DESCRIPTION
Closes #265

---

feat: apply API-Version header globally via middleware